### PR TITLE
SDK info

### DIFF
--- a/Pusher Platform iOS Example/Pusher Platform iOS Example/ViewController.swift
+++ b/Pusher Platform iOS Example/Pusher Platform iOS Example/ViewController.swift
@@ -35,6 +35,7 @@ class ViewController: UIViewController {
             locator: instanceLocator,
             serviceName: "chatkit",
             serviceVersion: "v1",
+            sdkInfo: PPSDKInfo(productName: "chatkit", sdkVersion: "0.0.0"),
             tokenProvider: tokenProvider,
 //            client: localBaseClient,
             logger: TestLogger()

--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		332E05E81DDCA919007A55FB /* PPMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332E05E71DDCA919007A55FB /* PPMessage.swift */; };
 		33347F4C1FFE7F7F00E9D140 /* PPDownloadFileDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33347F4B1FFE7F7F00E9D140 /* PPDownloadFileDestination.swift */; };
 		3337CF6220349CE1000892B6 /* PusherPlatform.h in Headers */ = {isa = PBXBuildFile; fileRef = 3337CF6120349CE1000892B6 /* PusherPlatform.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3337CF652035E9FD000892B6 /* PPSDKInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3337CF642035E9FD000892B6 /* PPSDKInfo.swift */; };
 		334B9A2F1ECCA295007A3D3B /* PPDefaultLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334B9A2E1ECCA295007A3D3B /* PPDefaultLogger.swift */; };
 		334ED1F01FE96CE20041A9CA /* PPDownloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334ED1EF1FE96CE20041A9CA /* PPDownloadDelegate.swift */; };
 		336F2A391FFBF1510098687B /* PPGeneralRequestURLSessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336F2A381FFBF1510098687B /* PPGeneralRequestURLSessionDelegate.swift */; };
@@ -56,6 +57,7 @@
 		332E05E71DDCA919007A55FB /* PPMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPMessage.swift; sourceTree = "<group>"; };
 		33347F4B1FFE7F7F00E9D140 /* PPDownloadFileDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPDownloadFileDestination.swift; sourceTree = "<group>"; };
 		3337CF6120349CE1000892B6 /* PusherPlatform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PusherPlatform.h; sourceTree = "<group>"; };
+		3337CF642035E9FD000892B6 /* PPSDKInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPSDKInfo.swift; sourceTree = "<group>"; };
 		334B9A2E1ECCA295007A3D3B /* PPDefaultLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPDefaultLogger.swift; sourceTree = "<group>"; };
 		334ED1EF1FE96CE20041A9CA /* PPDownloadDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPDownloadDelegate.swift; sourceTree = "<group>"; };
 		336F2A381FFBF1510098687B /* PPGeneralRequestURLSessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPGeneralRequestURLSessionDelegate.swift; sourceTree = "<group>"; };
@@ -148,6 +150,7 @@
 				33ECD9DA1EB881B50091BF66 /* PPDefaultRetryStrategy.swift */,
 				330DD21B1E0C433A00EC251F /* PPLogger.swift */,
 				334B9A2E1ECCA295007A3D3B /* PPDefaultLogger.swift */,
+				3337CF642035E9FD000892B6 /* PPSDKInfo.swift */,
 				33DD996F1FE195DE00A15211 /* PPMultipartFormData.swift */,
 				33347F4B1FFE7F7F00E9D140 /* PPDownloadFileDestination.swift */,
 				A1C545361F753E3700F15509 /* PPHTTPBodyPair.swift */,
@@ -324,6 +327,7 @@
 				336F2A391FFBF1510098687B /* PPGeneralRequestURLSessionDelegate.swift in Sources */,
 				33816B041EB36E7F00E5A169 /* PPRequestOptions.swift in Sources */,
 				332E05E61DDCA3DB007A55FB /* PPMessageParser.swift in Sources */,
+				3337CF652035E9FD000892B6 /* PPSDKInfo.swift in Sources */,
 				336F2A3B1FFBF17E0098687B /* PPSubscriptionURLSessionDelegate.swift in Sources */,
 				334ED1F01FE96CE20041A9CA /* PPDownloadDelegate.swift in Sources */,
 				A1C545371F753E3700F15509 /* PPHTTPBodyPair.swift in Sources */,

--- a/Sources/Instance.swift
+++ b/Sources/Instance.swift
@@ -17,9 +17,10 @@ import Foundation
         locator: String,
         serviceName: String,
         serviceVersion: String,
+        sdkInfo: PPSDKInfo,
         tokenProvider: PPTokenProvider? = nil,
         client: PPBaseClient? = nil,
-        logger: PPLogger? = nil
+        logger: PPLogger = PPDefaultLogger()
     ) {
         assert (!locator.isEmpty, "Expected locator property in Instance!")
         let splitInstance = locator.components(separatedBy: ":")
@@ -35,12 +36,12 @@ import Foundation
         let cluster = splitInstance[1]
         let host = "\(cluster).pusherplatform.io"
         self.host = host
-        self.client = client ?? PPBaseClient(host: host)
 
-        self.logger = logger ?? PPDefaultLogger()
-        if self.client.logger == nil {
-            self.client.logger = self.logger
-        }
+        self.logger = logger
+
+        self.client = client ?? PPBaseClient(host: host)
+        self.client.sdkInfo = self.client.sdkInfo ?? sdkInfo
+        self.client.logger = self.client.logger ?? logger
     }
 
     @discardableResult

--- a/Sources/PPSDKInfo.swift
+++ b/Sources/PPSDKInfo.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public struct PPSDKInfo {
+    let productName: String
+    let sdkVersion: String
+    let sdkLanguage: String = "swift"
+    let platform: String
+
+    private init(productName: String, sdkVersion: String, platform: String) {
+        self.productName = productName
+        self.sdkVersion = sdkVersion
+        self.platform = platform
+    }
+
+    #if os(macOS)
+    public init(productName: String, sdkVersion: String) {
+        self.init(productName: productName, sdkVersion: sdkVersion, platform: "macOS")
+    }
+    #elseif os(iOS)
+    public init(productName: String, sdkVersion: String) {
+        self.init(productName: productName, sdkVersion: sdkVersion, platform: "iOS")
+    }
+    #elseif os(tvOS)
+    public init(productName: String, sdkVersion: String) {
+        self.init(productName: productName, sdkVersion: sdkVersion, platform: "tvOS")
+    }
+    #elseif os(watchOS)
+    public init(productName: String, sdkVersion: String) {
+        self.init(productName: productName, sdkVersion: sdkVersion, platform: "watchOS")
+    }
+    #elseif os(Linux)
+    public init(productName: String, sdkVersion: String) {
+        self.init(productName: productName, sdkVersion: sdkVersion, platform: "Linux")
+    }
+    #else
+    public init(productName: String, sdkVersion: String, platform: String) {
+        self.init(productName: productName, sdkVersion: sdkVersion, platform: platform)
+    }
+    #endif
+
+    lazy var headers: [String: String] = {
+        return [
+            "X-SDK-Product": self.productName,
+            "X-SDK-Version": self.sdkVersion,
+            "X-SDK-Language": self.sdkLanguage,
+            "X-SDK-Platform": self.platform
+        ]
+    }()
+}


### PR DESCRIPTION
### What?

Add support for providing SDK information that gets translated into additional headers sent with requests. 

Currently it's very simple and adds the headers to every request. It might be good to have an option to remove the headers for individual requests as I could see them getting in the way or being undesirable in some cases, e.g. in Chatkit we have requests that can go to the file storage service we use.

### Why?

So we can have visibility of which SDK versions are being used

Example of usage: https://github.com/pusher/chatkit-swift/pull/65

----

CC @pusher/sigsdk