### PR TITLE
Concurrency fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/pusher-platform-swift/compare/0.7.0...HEAD)
+## [Unreleased](https://github.com/pusher/pusher-platform-swift/compare/0.7.1...HEAD)
+
+## [0.7.1](https://github.com/pusher/pusher-platform-swift/compare/0.7.0...0.7.1) - 2019-03-05
+
+### Fixed
+
+- PPBaseURLSessionDelegate uses a serial queue instead of a concurrent queue. Previously
+  the concurrent queue was not appropriately guarded so we could get outdated values.
 
 ## [0.7.0](https://github.com/pusher/pusher-platform-swift/compare/0.6.4...0.7.0) - 2019-01-31
 

--- a/PusherPlatform.podspec
+++ b/PusherPlatform.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PusherPlatform'
-  s.version          = '0.7.0'
+  s.version          = '0.7.1'
   s.summary          = 'Pusher Platform SDK in Swift'
   s.homepage         = 'https://github.com/pusher/pusher-platform-swift'
   s.license          = 'MIT'

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.0</string>
+	<string>0.7.1</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>CFBundleSignature</key>

--- a/Sources/PPBaseURLSessionDelegate.swift
+++ b/Sources/PPBaseURLSessionDelegate.swift
@@ -6,8 +6,7 @@ public class PPBaseURLSessionDelegate<RequestTaskDelegate: PPRequestTaskDelegate
     public var insecure: Bool
     public var requests: [TaskIdentifier: PPRequest<RequestTaskDelegate>] = [:]
     private let requestAccessQueue = DispatchQueue(
-        label: "com.pusherplatform.swift.session-requests.\(UUID().uuidString)",
-        attributes: .concurrent
+        label: "com.pusherplatform.swift.session-requests.\(UUID().uuidString)"
     )
 
     public var logger: PPLogger? = nil {

--- a/Sources/PPResumableSubscription.swift
+++ b/Sources/PPResumableSubscription.swift
@@ -265,14 +265,15 @@ import Foundation
     }
 
     func setupNewSubscription() {
-        guard let subscriptionDelegate = self.subscription?.delegate else {
+        guard let subscription = self.subscription else {
             self.instance.logger.log(
-                "No delegate for subscription: \(self.subscription.debugDescription)",
+                "Subscription is nil for resumable subscription: \(self.debugDescription)",
                 logLevel: .error
             )
             return
         }
 
+        let subscriptionDelegate = subscription.delegate
         self.cancelExistingSubscriptionTask(subscriptionDelegate: subscriptionDelegate)
         self.cleanUpOldSubscription(subscriptionDelegate: subscriptionDelegate)
 

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.0</string>
+	<string>0.7.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
### What?

- Use a serial queue to control access to the dictionary in `PPBaseURLSessionDelegate`. 
- More defensive coding around optional subscription.

### Why?

Previously the queue was `concurrent`, but we were using synchronous operations without barriers in which case data races could happen. This changes makes the operations synchronous with a a serial queue.

----

CC @pusher/sigsdk