### PR TITLE
Remove swiftlint

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -16,7 +16,3 @@ warn 'PR is classed as Work in Progress' if github.pr_title.include? '[WIP]'
 if git.commits.any? { |c| c.message =~ /^Merge branch 'master'/ }
   warn 'Please rebase to get rid of the merge commits in this PR'
 end
-
-# Run SwiftLint
-# Add fail_on_error: true if we want to make linting errors fail the build
-swiftlint.lint_files

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'danger', '~> 5.0'
-gem 'danger-swiftlint', '~> 0.13'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,10 +23,6 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    danger-swiftlint (0.13.1)
-      danger
-      rake (> 10)
-      thor (~> 0.19)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
@@ -40,13 +36,11 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     public_suffix (3.0.2)
-    rake (12.3.0)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thor (0.20.0)
     unicode-display_width (1.3.0)
 
 PLATFORMS
@@ -54,7 +48,6 @@ PLATFORMS
 
 DEPENDENCIES
   danger (~> 5.0)
-  danger-swiftlint (~> 0.13)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
### What?

See title.

### Why?

Rules need to be discussed in order to make lint's output more valuable.
Removing it at this point as it produces too much noise.

----

CC @pusher/sigsdk
