### PR TITLE
Persistence

### DIFF
--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -521,7 +521,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator appletvsimulator watchsimulator watchos appletvos iphoneos";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
@@ -564,7 +564,7 @@
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator appletvsimulator watchsimulator watchos appletvos iphoneos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
@@ -625,7 +625,6 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator watchsimulator watchos appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -678,7 +677,6 @@
 				SDKROOT = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator watchsimulator watchos appletvos";
-				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -738,7 +736,6 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos watchsimulator watchos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -787,7 +784,6 @@
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos watchsimulator watchos";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		222BAAEE22F489180050B196 /* PersistenceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAED22F489180050B196 /* PersistenceError.swift */; };
 		22F0A46F22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */; };
 		22F0A47122F822E400787225 /* ErrorRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */; };
+		22F0A47422F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47322F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift */; };
+		22F0A47722F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */; };
 		22528E8722F994CE00F25C1C /* DispatchSemaphore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */; };
 		3301FDD92045984900AE591A /* PusherPlatform.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33831C891A9CF61600B124F1 /* PusherPlatform.framework */; };
 		3301FDDE2047035500AE591A /* SDKInfoHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */; };
@@ -62,6 +64,8 @@
 		222BAAED22F489180050B196 /* PersistenceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceError.swift; sourceTree = "<group>"; };
 		22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentStoreDescription+RLBErrorRecovery.swift"; sourceTree = "<group>"; };
 		22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorRecoveryPolicy.swift; sourceTree = "<group>"; };
+		22F0A47322F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPersistentStoreDescription+StoreTypes.swift"; sourceTree = "<group>"; };
+		22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPersistentStoreDescription_StoreTypesTests.swift; sourceTree = "<group>"; };
 		22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSemaphore.swift; sourceTree = "<group>"; };
 		3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKInfoHeaderTests.swift; sourceTree = "<group>"; };
 		33025C06212B346800C12249 /* PPRepeater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPRepeater.swift; sourceTree = "<group>"; };
@@ -125,6 +129,7 @@
 			children = (
 				222BAAE922F453250050B196 /* Controller */,
 				222BAAEC22F489010050B196 /* Error Handling */,
+				22F0A47222F8599700787225 /* Store Description */,
 			);
 			name = Persistence;
 			sourceTree = "<group>";
@@ -153,6 +158,22 @@
 				22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */,
 			);
 			name = "Error Recovery";
+			sourceTree = "<group>";
+		};
+		22F0A47222F8599700787225 /* Store Description */ = {
+			isa = PBXGroup;
+			children = (
+				22F0A47322F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift */,
+			);
+			name = "Store Description";
+			sourceTree = "<group>";
+		};
+		22F0A47522F8629500787225 /* Persistence */ = {
+			isa = PBXGroup;
+			children = (
+				22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */,
+			);
+			path = Persistence;
 			sourceTree = "<group>";
 		};
 		3301FDD7204597A900AE591A /* Frameworks */ = {
@@ -241,6 +262,7 @@
 		33BB995C1D21225B00B25C2A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				22F0A47522F8629500787225 /* Persistence */,
 				33C2FB141F3E99C4006AB501 /* MessageParserTests.swift */,
 				3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */,
 				33BB99671D21226C00B25C2A /* Info.plist */,
@@ -389,6 +411,7 @@
 				22F0A46F22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift in Sources */,
 				3337CF652035E9FD000892B6 /* PPSDKInfo.swift in Sources */,
 				336F2A3B1FFBF17E0098687B /* PPSubscriptionURLSessionDelegate.swift in Sources */,
+				22F0A47422F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift in Sources */,
 				334ED1F01FE96CE20041A9CA /* PPDownloadDelegate.swift in Sources */,
 				A1C545371F753E3700F15509 /* PPHTTPBodyPair.swift in Sources */,
 				332E05E81DDCA919007A55FB /* PPMessage.swift in Sources */,
@@ -408,6 +431,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33C2FB151F3E99C4006AB501 /* MessageParserTests.swift in Sources */,
+				22F0A47722F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift in Sources */,
 				3301FDDE2047035500AE591A /* SDKInfoHeaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -11,11 +11,13 @@
 		222BAAEB22F453310050B196 /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAEA22F453310050B196 /* PersistenceController.swift */; };
 		222BAAEE22F489180050B196 /* PersistenceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAED22F489180050B196 /* PersistenceError.swift */; };
 		22528E8722F994CE00F25C1C /* DispatchSemaphore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */; };
+		2296D72422F9DC1D00921EDA /* TestModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 2296D72122F9DB6300921EDA /* TestModel.xcdatamodeld */; };
 		22F0A46F22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */; };
 		22F0A47122F822E400787225 /* ErrorRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */; };
 		22F0A47422F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47322F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift */; };
 		22F0A47722F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */; };
 		22F0A47B22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */; };
+		22F0A47D22F879AA00787225 /* PersistenceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47C22F879AA00787225 /* PersistenceControllerTests.swift */; };
 		3301FDD92045984900AE591A /* PusherPlatform.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33831C891A9CF61600B124F1 /* PusherPlatform.framework */; };
 		3301FDDE2047035500AE591A /* SDKInfoHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */; };
 		33025C07212B346800C12249 /* PPRepeater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33025C06212B346800C12249 /* PPRepeater.swift */; };
@@ -66,11 +68,13 @@
 		222BAAEA22F453310050B196 /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
 		222BAAED22F489180050B196 /* PersistenceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceError.swift; sourceTree = "<group>"; };
 		22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSemaphore.swift; sourceTree = "<group>"; };
+		2296D72222F9DB6300921EDA /* TestModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestModel.xcdatamodel; sourceTree = "<group>"; };
 		22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentStoreDescription+RLBErrorRecovery.swift"; sourceTree = "<group>"; };
 		22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorRecoveryPolicy.swift; sourceTree = "<group>"; };
 		22F0A47322F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPersistentStoreDescription+StoreTypes.swift"; sourceTree = "<group>"; };
 		22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPersistentStoreDescription_StoreTypesTests.swift; sourceTree = "<group>"; };
 		22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPersistentStoreDescription_RecoveryTests.swift; sourceTree = "<group>"; };
+		22F0A47C22F879AA00787225 /* PersistenceControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceControllerTests.swift; sourceTree = "<group>"; };
 		3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKInfoHeaderTests.swift; sourceTree = "<group>"; };
 		33025C06212B346800C12249 /* PPRepeater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPRepeater.swift; sourceTree = "<group>"; };
 		330DD21B1E0C433A00EC251F /* PPLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPLogger.swift; sourceTree = "<group>"; };
@@ -101,7 +105,7 @@
 		33935EA71DA5399A00C5C064 /* PPTokenProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPTokenProvider.swift; sourceTree = "<group>"; };
 		33935EAB1DA539BD00C5C064 /* PPHTTPEndpointTokenProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPHTTPEndpointTokenProvider.swift; sourceTree = "<group>"; };
 		33935EAF1DA53BCF00C5C064 /* PPBaseClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPBaseClient.swift; sourceTree = "<group>"; };
-		33BB99671D21226C00B25C2A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
+		33BB99671D21226C00B25C2A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		33C2FB141F3E99C4006AB501 /* MessageParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MessageParserTests.swift; path = ../Tests/MessageParserTests.swift; sourceTree = "<group>"; };
 		33DD996F1FE195DE00A15211 /* PPMultipartFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPMultipartFormData.swift; sourceTree = "<group>"; };
 		33ECD9DA1EB881B50091BF66 /* PPDefaultRetryStrategy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPDefaultRetryStrategy.swift; sourceTree = "<group>"; };
@@ -134,6 +138,14 @@
 				220E87CD22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift */,
 			);
 			name = Context;
+			sourceTree = "<group>";
+		};
+		220E87CF22FAF62B008B3B95 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				2296D72122F9DB6300921EDA /* TestModel.xcdatamodeld */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		222BAAE822F4531B0050B196 /* Persistence */ = {
@@ -186,6 +198,7 @@
 			children = (
 				22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */,
 				22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */,
+				22F0A47C22F879AA00787225 /* PersistenceControllerTests.swift */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -276,6 +289,7 @@
 		33BB995C1D21225B00B25C2A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				220E87CF22FAF62B008B3B95 /* Model */,
 				22F0A47522F8629500787225 /* Persistence */,
 				33C2FB141F3E99C4006AB501 /* MessageParserTests.swift */,
 				3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */,
@@ -447,6 +461,8 @@
 			files = (
 				33C2FB151F3E99C4006AB501 /* MessageParserTests.swift in Sources */,
 				22F0A47722F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift in Sources */,
+				22F0A47D22F879AA00787225 /* PersistenceControllerTests.swift in Sources */,
+				2296D72422F9DC1D00921EDA /* TestModel.xcdatamodeld in Sources */,
 				3301FDDE2047035500AE591A /* SDKInfoHeaderTests.swift in Sources */,
 				22F0A47B22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift in Sources */,
 			);
@@ -803,6 +819,19 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		2296D72122F9DB6300921EDA /* TestModel.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				2296D72222F9DB6300921EDA /* TestModel.xcdatamodel */,
+			);
+			currentVersion = 2296D72222F9DB6300921EDA /* TestModel.xcdatamodel */;
+			path = TestModel.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 33831C4A1A9CEDF800B124F1 /* Project object */;
 }

--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		222BAAEB22F453310050B196 /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAEA22F453310050B196 /* PersistenceController.swift */; };
+		222BAAEE22F489180050B196 /* PersistenceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAED22F489180050B196 /* PersistenceError.swift */; };
+		22F0A46F22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */; };
+		22F0A47122F822E400787225 /* ErrorRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */; };
 		22528E8722F994CE00F25C1C /* DispatchSemaphore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */; };
 		3301FDD92045984900AE591A /* PusherPlatform.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33831C891A9CF61600B124F1 /* PusherPlatform.framework */; };
 		3301FDDE2047035500AE591A /* SDKInfoHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */; };
@@ -54,6 +58,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		222BAAEA22F453310050B196 /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
+		222BAAED22F489180050B196 /* PersistenceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceError.swift; sourceTree = "<group>"; };
+		22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentStoreDescription+RLBErrorRecovery.swift"; sourceTree = "<group>"; };
+		22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorRecoveryPolicy.swift; sourceTree = "<group>"; };
 		22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSemaphore.swift; sourceTree = "<group>"; };
 		3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKInfoHeaderTests.swift; sourceTree = "<group>"; };
 		33025C06212B346800C12249 /* PPRepeater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPRepeater.swift; sourceTree = "<group>"; };
@@ -112,6 +120,41 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		222BAAE822F4531B0050B196 /* Persistence */ = {
+			isa = PBXGroup;
+			children = (
+				222BAAE922F453250050B196 /* Controller */,
+				222BAAEC22F489010050B196 /* Error Handling */,
+			);
+			name = Persistence;
+			sourceTree = "<group>";
+		};
+		222BAAE922F453250050B196 /* Controller */ = {
+			isa = PBXGroup;
+			children = (
+				222BAAEA22F453310050B196 /* PersistenceController.swift */,
+			);
+			name = Controller;
+			sourceTree = "<group>";
+		};
+		222BAAEC22F489010050B196 /* Error Handling */ = {
+			isa = PBXGroup;
+			children = (
+				22F0A46D22F8223100787225 /* Error Recovery */,
+				222BAAED22F489180050B196 /* PersistenceError.swift */,
+			);
+			name = "Error Handling";
+			sourceTree = "<group>";
+		};
+		22F0A46D22F8223100787225 /* Error Recovery */ = {
+			isa = PBXGroup;
+			children = (
+				22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */,
+				22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */,
+			);
+			name = "Error Recovery";
+			sourceTree = "<group>";
+		};
 		3301FDD7204597A900AE591A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -142,6 +185,7 @@
 		33831C8B1A9CF61600B124F1 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				222BAAE822F4531B0050B196 /* Persistence */,
 				338290711DF5CEC6008CDC8F /* Instance.swift */,
 				33935EAF1DA53BCF00C5C064 /* PPBaseClient.swift */,
 				338202491FFCF02B00DC9664 /* PPBaseURLSessionDelegate.swift */,
@@ -286,6 +330,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 33831C491A9CEDF800B124F1;
@@ -330,6 +375,8 @@
 				33DD99701FE195DF00A15211 /* PPMultipartFormData.swift in Sources */,
 				3382024A1FFCF02B00DC9664 /* PPBaseURLSessionDelegate.swift in Sources */,
 				33935EB01DA53BCF00C5C064 /* PPBaseClient.swift in Sources */,
+				22F0A47122F822E400787225 /* ErrorRecoveryPolicy.swift in Sources */,
+				222BAAEB22F453310050B196 /* PersistenceController.swift in Sources */,
 				331F9BB71EB8D3F200C3F678 /* PPRetryableGeneralRequest.swift in Sources */,
 				330DD21C1E0C433A00EC251F /* PPLogger.swift in Sources */,
 				33F37F781E0C20CC0048457F /* PPRequest.swift in Sources */,
@@ -339,6 +386,7 @@
 				33025C07212B346800C12249 /* PPRepeater.swift in Sources */,
 				22528E8722F994CE00F25C1C /* DispatchSemaphore.swift in Sources */,
 				332E05E61DDCA3DB007A55FB /* PPMessageParser.swift in Sources */,
+				22F0A46F22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift in Sources */,
 				3337CF652035E9FD000892B6 /* PPSDKInfo.swift in Sources */,
 				336F2A3B1FFBF17E0098687B /* PPSubscriptionURLSessionDelegate.swift in Sources */,
 				334ED1F01FE96CE20041A9CA /* PPDownloadDelegate.swift in Sources */,
@@ -346,6 +394,7 @@
 				332E05E81DDCA919007A55FB /* PPMessage.swift in Sources */,
 				338202501FFCFF3B00DC9664 /* PPUploadURLSessionDelegate.swift in Sources */,
 				33935EAC1DA539BD00C5C064 /* PPHTTPEndpointTokenProvider.swift in Sources */,
+				222BAAEE22F489180050B196 /* PersistenceError.swift in Sources */,
 				33816B081EB379F800E5A169 /* PPGeneralRequestDelegate.swift in Sources */,
 				33816B061EB375AA00E5A169 /* PPRequestTaskDelegate.swift in Sources */,
 				3382024C1FFCFEBB00DC9664 /* PPUploadDelegate.swift in Sources */,

--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -7,14 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		220E87CE22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220E87CD22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift */; };
 		222BAAEB22F453310050B196 /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAEA22F453310050B196 /* PersistenceController.swift */; };
 		222BAAEE22F489180050B196 /* PersistenceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAED22F489180050B196 /* PersistenceError.swift */; };
+		22528E8722F994CE00F25C1C /* DispatchSemaphore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */; };
 		22F0A46F22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */; };
 		22F0A47122F822E400787225 /* ErrorRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */; };
 		22F0A47422F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47322F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift */; };
 		22F0A47722F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */; };
 		22F0A47B22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */; };
-		22528E8722F994CE00F25C1C /* DispatchSemaphore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */; };
 		3301FDD92045984900AE591A /* PusherPlatform.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33831C891A9CF61600B124F1 /* PusherPlatform.framework */; };
 		3301FDDE2047035500AE591A /* SDKInfoHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */; };
 		33025C07212B346800C12249 /* PPRepeater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33025C06212B346800C12249 /* PPRepeater.swift */; };
@@ -61,14 +62,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		220E87CD22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Persistence.swift"; sourceTree = "<group>"; };
 		222BAAEA22F453310050B196 /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
 		222BAAED22F489180050B196 /* PersistenceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceError.swift; sourceTree = "<group>"; };
+		22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSemaphore.swift; sourceTree = "<group>"; };
 		22F0A46E22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentStoreDescription+RLBErrorRecovery.swift"; sourceTree = "<group>"; };
 		22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorRecoveryPolicy.swift; sourceTree = "<group>"; };
 		22F0A47322F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPersistentStoreDescription+StoreTypes.swift"; sourceTree = "<group>"; };
 		22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPersistentStoreDescription_StoreTypesTests.swift; sourceTree = "<group>"; };
 		22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPersistentStoreDescription_RecoveryTests.swift; sourceTree = "<group>"; };
-		22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSemaphore.swift; sourceTree = "<group>"; };
 		3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKInfoHeaderTests.swift; sourceTree = "<group>"; };
 		33025C06212B346800C12249 /* PPRepeater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPRepeater.swift; sourceTree = "<group>"; };
 		330DD21B1E0C433A00EC251F /* PPLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPLogger.swift; sourceTree = "<group>"; };
@@ -126,9 +128,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		220E87CC22FAC9E4008B3B95 /* Context */ = {
+			isa = PBXGroup;
+			children = (
+				220E87CD22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift */,
+			);
+			name = Context;
+			sourceTree = "<group>";
+		};
 		222BAAE822F4531B0050B196 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				220E87CC22FAC9E4008B3B95 /* Context */,
 				222BAAE922F453250050B196 /* Controller */,
 				222BAAEC22F489010050B196 /* Error Handling */,
 				22F0A47222F8599700787225 /* Store Description */,
@@ -424,6 +435,7 @@
 				33816B081EB379F800E5A169 /* PPGeneralRequestDelegate.swift in Sources */,
 				33816B061EB375AA00E5A169 /* PPRequestTaskDelegate.swift in Sources */,
 				3382024C1FFCFEBB00DC9664 /* PPUploadDelegate.swift in Sources */,
+				220E87CE22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift in Sources */,
 				33935EA81DA5399A00C5C064 /* PPTokenProvider.swift in Sources */,
 				33816B001EB3446900E5A169 /* PPRetryStrategy.swift in Sources */,
 			);

--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		22029BAC22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22029BAB22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift */; };
 		220E87CE22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220E87CD22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift */; };
 		222BAAEB22F453310050B196 /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAEA22F453310050B196 /* PersistenceController.swift */; };
 		222BAAEE22F489180050B196 /* PersistenceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAED22F489180050B196 /* PersistenceError.swift */; };
@@ -64,6 +65,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		22029BAB22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSManagedObjectContext_PersistenceTests.swift; sourceTree = "<group>"; };
 		220E87CD22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Persistence.swift"; sourceTree = "<group>"; };
 		222BAAEA22F453310050B196 /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
 		222BAAED22F489180050B196 /* PersistenceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceError.swift; sourceTree = "<group>"; };
@@ -196,6 +198,7 @@
 		22F0A47522F8629500787225 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				22029BAB22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift */,
 				22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */,
 				22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */,
 				22F0A47C22F879AA00787225 /* PersistenceControllerTests.swift */,
@@ -460,6 +463,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33C2FB151F3E99C4006AB501 /* MessageParserTests.swift in Sources */,
+				22029BAC22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift in Sources */,
 				22F0A47722F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift in Sources */,
 				22F0A47D22F879AA00787225 /* PersistenceControllerTests.swift in Sources */,
 				2296D72422F9DC1D00921EDA /* TestModel.xcdatamodeld in Sources */,

--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		22F0A47122F822E400787225 /* ErrorRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */; };
 		22F0A47422F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47322F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift */; };
 		22F0A47722F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */; };
+		22F0A47B22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */; };
 		22528E8722F994CE00F25C1C /* DispatchSemaphore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */; };
 		3301FDD92045984900AE591A /* PusherPlatform.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33831C891A9CF61600B124F1 /* PusherPlatform.framework */; };
 		3301FDDE2047035500AE591A /* SDKInfoHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */; };
@@ -66,6 +67,7 @@
 		22F0A47022F822E400787225 /* ErrorRecoveryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorRecoveryPolicy.swift; sourceTree = "<group>"; };
 		22F0A47322F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPersistentStoreDescription+StoreTypes.swift"; sourceTree = "<group>"; };
 		22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPersistentStoreDescription_StoreTypesTests.swift; sourceTree = "<group>"; };
+		22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPersistentStoreDescription_RecoveryTests.swift; sourceTree = "<group>"; };
 		22528E8622F994CE00F25C1C /* DispatchSemaphore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchSemaphore.swift; sourceTree = "<group>"; };
 		3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKInfoHeaderTests.swift; sourceTree = "<group>"; };
 		33025C06212B346800C12249 /* PPRepeater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPRepeater.swift; sourceTree = "<group>"; };
@@ -171,6 +173,7 @@
 		22F0A47522F8629500787225 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */,
 				22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */,
 			);
 			path = Persistence;
@@ -433,6 +436,7 @@
 				33C2FB151F3E99C4006AB501 /* MessageParserTests.swift in Sources */,
 				22F0A47722F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift in Sources */,
 				3301FDDE2047035500AE591A /* SDKInfoHeaderTests.swift in Sources */,
+				22F0A47B22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ErrorRecoveryPolicy.swift
+++ b/Sources/ErrorRecoveryPolicy.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public enum ErrorRecoveryPolicy {
+    
+    case fail
+    case deleteStore
+    case backupStore(URL)
+    
+}
+
+// MARK: - Equatable
+
+extension ErrorRecoveryPolicy: Equatable {
+    
+    public static func == (lhs: ErrorRecoveryPolicy, rhs: ErrorRecoveryPolicy) -> Bool {
+        switch (lhs, rhs) {
+        case (.fail, .fail),
+             (.deleteStore, .deleteStore):
+            return true
+            
+        case let (.backupStore(lhsURL), .backupStore(rhsURL)):
+            return lhsURL == rhsURL
+            
+        default:
+            return false
+        }
+    }
+    
+}

--- a/Sources/NSManagedObjectContext+Persistence.swift
+++ b/Sources/NSManagedObjectContext+Persistence.swift
@@ -26,7 +26,12 @@ public extension NSManagedObjectContext {
     }
     
     func deleteAll<T: NSManagedObject>(_ entity: T.Type, predicateFormat: String, _ predicateArguments: CVarArg...) {
-        let predicate = NSPredicate(format: predicateFormat, predicateArguments)
+        var predicate: NSPredicate? = nil
+        
+        withVaList(predicateArguments) { arguments in
+            predicate = NSPredicate(format: predicateFormat, arguments: arguments)
+        }
+        
         deleteAll(entity, predicate: predicate)
     }
     
@@ -35,7 +40,12 @@ public extension NSManagedObjectContext {
     }
     
     func fetch<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, predicateFormat: String, _ predicateArguments: CVarArg...) -> T? {
-        let predicate = NSPredicate(format: predicateFormat, predicateArguments)
+        var predicate: NSPredicate? = nil
+        
+        withVaList(predicateArguments) { arguments in
+            predicate = NSPredicate(format: predicateFormat, arguments: arguments)
+        }
+        
         return fetch(entity, sortDescriptors: sortDescriptors, predicate: predicate)
     }
     
@@ -49,7 +59,12 @@ public extension NSManagedObjectContext {
     }
     
     func fetchAll<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, fetchLimit: Int = 0, predicateFormat: String, _ predicateArguments: CVarArg...) -> [T] {
-        let predicate = NSPredicate(format: predicateFormat, predicateArguments)
+        var predicate: NSPredicate? = nil
+        
+        withVaList(predicateArguments) { arguments in
+            predicate = NSPredicate(format: predicateFormat, arguments: arguments)
+        }
+        
         return fetchAll(entity, sortDescriptors: sortDescriptors, fetchLimit: fetchLimit, predicate: predicate)
     }
     
@@ -61,7 +76,12 @@ public extension NSManagedObjectContext {
     }
     
     func count<T: NSManagedObject>(_ entity: T.Type, predicateFormat: String, _ predicateArguments: CVarArg...) -> Int {
-        let predicate = NSPredicate(format: predicateFormat, predicateArguments)
+        var predicate: NSPredicate? = nil
+        
+        withVaList(predicateArguments) { arguments in
+            predicate = NSPredicate(format: predicateFormat, arguments: arguments)
+        }
+        
         return count(entity, predicate: predicate)
     }
     

--- a/Sources/NSManagedObjectContext+Persistence.swift
+++ b/Sources/NSManagedObjectContext+Persistence.swift
@@ -1,0 +1,68 @@
+import Foundation
+import CoreData
+
+public extension NSManagedObjectContext {
+    
+    // MARK: - Public methods
+
+    func create<T: NSManagedObject>(_ entity: T.Type) -> T {
+        return NSEntityDescription.insertNewObject(forEntityName: String(describing: T.self), into: self) as! T
+    }
+    
+    func delete(with objectID: NSManagedObjectID) {
+        guard let object = try? existingObject(with: objectID) else {
+            return
+        }
+        
+        delete(object)
+    }
+    
+    func deleteAll<T: NSManagedObject>(_ entity: T.Type, predicate: NSPredicate? = nil) {
+        let objects = fetchAll(entity, predicate: predicate)
+        
+        for object in objects {
+            delete(object)
+        }
+    }
+    
+    func deleteAll<T: NSManagedObject>(_ entity: T.Type, predicateFormat: String, _ predicateArguments: CVarArg...) {
+        let predicate = NSPredicate(format: predicateFormat, predicateArguments)
+        deleteAll(entity, predicate: predicate)
+    }
+    
+    func fetch<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, predicate: NSPredicate? = nil) -> T? {
+        return fetchAll(entity, sortDescriptors: sortDescriptors, predicate: predicate).first
+    }
+    
+    func fetch<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, predicateFormat: String, _ predicateArguments: CVarArg...) -> T? {
+        let predicate = NSPredicate(format: predicateFormat, predicateArguments)
+        return fetch(entity, sortDescriptors: sortDescriptors, predicate: predicate)
+    }
+    
+    func fetchAll<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, fetchLimit: Int = 0, predicate: NSPredicate? = nil) -> [T] {
+        let fetchRequest = NSFetchRequest<T>(entityName: String(describing: T.self))
+        fetchRequest.sortDescriptors = sortDescriptors
+        fetchRequest.fetchLimit = fetchLimit
+        fetchRequest.predicate = predicate
+        
+        return (try? fetch(fetchRequest)) ?? [T]()
+    }
+    
+    func fetchAll<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, fetchLimit: Int = 0, predicateFormat: String, _ predicateArguments: CVarArg...) -> [T] {
+        let predicate = NSPredicate(format: predicateFormat, predicateArguments)
+        return fetchAll(entity, sortDescriptors: sortDescriptors, fetchLimit: fetchLimit, predicate: predicate)
+    }
+    
+    func count<T: NSManagedObject>(_ entity: T.Type, predicate: NSPredicate? = nil) -> Int {
+        let fetchRequest = NSFetchRequest<T>(entityName: String(describing: T.self))
+        fetchRequest.predicate = predicate
+        
+        return (try? count(for: fetchRequest)) ?? 0
+    }
+    
+    func count<T: NSManagedObject>(_ entity: T.Type, predicateFormat: String, _ predicateArguments: CVarArg...) -> Int {
+        let predicate = NSPredicate(format: predicateFormat, predicateArguments)
+        return count(entity, predicate: predicate)
+    }
+    
+}

--- a/Sources/NSPersistentStoreDescription+StoreTypes.swift
+++ b/Sources/NSPersistentStoreDescription+StoreTypes.swift
@@ -1,0 +1,48 @@
+import Foundation
+import CoreData
+
+public enum SQLiteJournalMode: String {
+    
+    case off = "OFF"
+    case writeAheadLog = "WAL"
+    case atomicCommitDelete = "DELETE"
+    case atomicCommitTruncate = "TRUNCATE"
+    case atomicCommitPersist = "PERSIST"
+    case atomicCommitMemory = "MEMORY"
+    
+}
+
+// MARK: -
+
+public extension NSPersistentStoreDescription {
+    
+    // MARK: - Initializers
+    
+    convenience init(inMemoryPersistentStoreDescription: ()) {
+        self.init(inMemoryPersistentStoreDescriptionForConfiguration: nil)
+    }
+    
+    convenience init(inMemoryPersistentStoreDescriptionForConfiguration configuration: String?, shouldAddStoreAsynchronously: Bool = true, shouldInferMappingModelAutomatically: Bool = true) {
+        self.init()
+        
+        self.type = NSInMemoryStoreType
+        self.configuration = configuration
+        self.shouldAddStoreAsynchronously = shouldAddStoreAsynchronously
+        self.shouldInferMappingModelAutomatically = shouldInferMappingModelAutomatically
+    }
+    
+    convenience init(sqlitePersistentStoreDescriptionWithURL url: URL, errorRecoveryPolicy: ErrorRecoveryPolicy, configuration: String? = nil, isReadOnly: Bool = false, journalMode: SQLiteJournalMode = .writeAheadLog, shouldAddStoreAsynchronously: Bool = true, shouldMigrateStoreAutomatically: Bool = true, shouldInferMappingModelAutomatically: Bool = true) {
+        self.init(url: url)
+        
+        self.type = NSSQLiteStoreType
+        self.errorRecoveryPolicy = errorRecoveryPolicy
+        self.configuration = configuration
+        self.isReadOnly = isReadOnly
+        self.shouldAddStoreAsynchronously = shouldAddStoreAsynchronously
+        self.shouldMigrateStoreAutomatically = shouldMigrateStoreAutomatically
+        self.shouldInferMappingModelAutomatically = shouldInferMappingModelAutomatically
+        
+        setValue(journalMode.rawValue as NSObject, forPragmaNamed: "journal_mode")
+    }
+
+}

--- a/Sources/PersistenceController.swift
+++ b/Sources/PersistenceController.swift
@@ -88,7 +88,7 @@ public class PersistenceController {
     
     // MARK: - Public methods
     
-    public func performBackgroundTask(backgroundTask: @escaping BackgroundTask) {
+    public func performBackgroundTask(_ backgroundTask: @escaping BackgroundTask) {
         let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         context.automaticallyMergesChangesFromParent = true
         context.parent = privateContext

--- a/Sources/PersistenceController.swift
+++ b/Sources/PersistenceController.swift
@@ -38,11 +38,6 @@ public class PersistenceController {
             throw PersistenceError.persistentStoreDescriptionMissing
         }
         
-        guard Thread.isMainThread else {
-            self.logger?.log("Due to thread confinement PersistenceController should always be instantiated on the main thread.", logLevel: .error)
-            throw PersistenceError.threadConfinementViolation
-        }
-        
         self.model = model
         self.storeCoordinator = NSPersistentStoreCoordinator(managedObjectModel: self.model)
         

--- a/Sources/PersistenceController.swift
+++ b/Sources/PersistenceController.swift
@@ -1,0 +1,205 @@
+import Foundation
+import CoreData
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+public class PersistenceController {
+    
+    // MARK: - Types
+    
+    public typealias CompletionHandler = (Error?) -> Void
+    public typealias BackgroundTask = (NSManagedObjectContext) -> Void
+    
+    // MARK: - Properties
+    
+    public let model: NSManagedObjectModel
+    public let storeCoordinator: NSPersistentStoreCoordinator
+    
+    private let privateContext: NSManagedObjectContext
+    public let mainContext: NSManagedObjectContext
+    
+    public let logger: PPLogger?
+    
+    public var shouldSaveWhenApplicationWillResignActive: Bool
+    public var shouldSaveWhenApplicationDidEnterBackground: Bool
+    public var shouldSaveWhenApplicationWillTerminate: Bool
+    
+    // MARK: - Initializers
+    
+    public init?(model: NSManagedObjectModel, storeDescriptions: [NSPersistentStoreDescription], logger: PPLogger? = nil, completionHandler: CompletionHandler? = nil) {
+        self.logger = logger
+        
+        guard storeDescriptions.count > 0 else {
+            self.logger?.log("At least one persistent store description is required to instantiated PersistenceController.", logLevel: .error)
+            
+            if let completionHandler = completionHandler {
+                completionHandler(PersistenceError.persistentStoreDescriptionMissing)
+            }
+            
+            return nil
+        }
+        
+        guard Thread.isMainThread else {
+            self.logger?.log("Due to thread confinement PersistenceController should always be instantiated on the main thread.", logLevel: .error)
+            
+            if let completionHandler = completionHandler {
+                completionHandler(PersistenceError.threadConfinementViolation)
+            }
+            
+            return nil
+        }
+        
+        self.model = model
+        self.storeCoordinator = NSPersistentStoreCoordinator(managedObjectModel: self.model)
+        
+        self.privateContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        self.privateContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        self.privateContext.persistentStoreCoordinator = self.storeCoordinator
+        
+        self.mainContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        self.mainContext.automaticallyMergesChangesFromParent = true
+        self.mainContext.parent = self.privateContext
+        
+        self.shouldSaveWhenApplicationWillResignActive = false
+        self.shouldSaveWhenApplicationDidEnterBackground = true
+        self.shouldSaveWhenApplicationWillTerminate = true
+        
+        registerForApplicationLifecycleNotifications()
+        addStores(for: storeDescriptions, completionHandler: completionHandler)
+    }
+    
+    public convenience init?(storeDescriptions: [NSPersistentStoreDescription], logger: PPLogger? = nil, completionHandler: CompletionHandler? = nil) {
+        guard let model = NSManagedObjectModel.mergedModel(from: nil) else {
+            logger?.log("Failed to locate object model in the main bundle.", logLevel: .error)
+            
+            if let completionHandler = completionHandler {
+                completionHandler(PersistenceError.objectModelNotFound)
+            }
+            
+            return nil
+        }
+        
+        self.init(model: model, storeDescriptions: storeDescriptions, logger: logger, completionHandler: completionHandler)
+    }
+    
+    // MARK: - Public methods
+    
+    public func performBackgroundTask(backgroundTask: @escaping BackgroundTask) {
+        let context = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
+        context.automaticallyMergesChangesFromParent = true
+        context.parent = privateContext
+        
+        context.perform {
+            backgroundTask(context)
+        }
+    }
+    
+    public func save() {
+        guard mainContext.hasChanges || privateContext.hasChanges else {
+            return
+        }
+        
+        mainContext.performAndWait {
+            do {
+                try mainContext.save()
+            } catch {
+                logger?.log("Failed to save main context with error: \(error.localizedDescription)", logLevel: .warning)
+            }
+            
+            privateContext.perform { [weak self] in
+                guard let self = self else { return }
+                
+                do {
+                    try self.privateContext.save()
+                } catch {
+                    self.logger?.log("Failed to save to persistent stores with error: \(error.localizedDescription)", logLevel: .warning)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Private methods
+    
+    private func addStores(for storeDescriptions: [NSPersistentStoreDescription], completionHandler: CompletionHandler?) {
+        if storeDescriptions.count == 0 {
+            if let completionHandler = completionHandler {
+                completionHandler(nil)
+            }
+            
+            return
+        }
+        
+        var mutableStoreDescriptions = storeDescriptions
+        let storeDescription = mutableStoreDescriptions.removeLast()
+        
+        addStore(for: storeDescription, shouldAttemptRecovery: true) { [weak self] error in
+            guard let self = self else { return }
+            
+            if let error = error {
+                self.logger?.log("Failed to add to persistent stores with error: \(error.localizedDescription)", logLevel: .warning)
+                
+                if let completionHandler = completionHandler {
+                    completionHandler(error)
+                }
+            }
+            else {
+                self.addStores(for: mutableStoreDescriptions, completionHandler: completionHandler)
+            }
+        }
+    }
+    
+    private func addStore(for storeDescription: NSPersistentStoreDescription, shouldAttemptRecovery: Bool, completionHandler: CompletionHandler?) {
+        storeCoordinator.addPersistentStore(with: storeDescription) { [weak self] _, error in
+            guard let self = self else { return }
+            
+            if error != nil, shouldAttemptRecovery {
+                storeDescription.attemptRecovery()
+                self.addStore(for: storeDescription, shouldAttemptRecovery: false, completionHandler: completionHandler)
+            }
+            else if let completionHandler = completionHandler {
+                completionHandler(error)
+            }
+        }
+    }
+    
+    private func registerForApplicationLifecycleNotifications() {
+        // Lifecycle notifications for watchOS are not supported.
+        
+        let notificationCenter = NotificationCenter.default
+        
+        #if os(iOS) || os(tvOS)
+        notificationCenter.addObserver(self, selector: #selector(applicationWillResignActive(notfication:)), name: UIApplication.willResignActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationDidEnterBackground(notfication:)), name: UIApplication.didEnterBackgroundNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationWillTerminate(notfication:)), name: UIApplication.willTerminateNotification, object: nil)
+        #elseif os(OSX)
+        notificationCenter.addObserver(self, selector: #selector(applicationWillResignActive(notfication:)), name: NSApplication.willResignActiveNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationDidEnterBackground(notfication:)), name: NSApplication.didHideNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(applicationWillTerminate(notfication:)), name: NSApplication.willTerminateNotification, object: nil)
+        #endif
+    }
+    
+    // MARK: - Notifications
+    
+    @objc private func applicationWillResignActive(notfication: NSNotification) {
+        if self.shouldSaveWhenApplicationWillResignActive {
+            save()
+        }
+    }
+    
+    @objc private func applicationDidEnterBackground(notfication: NSNotification) {
+        if self.shouldSaveWhenApplicationDidEnterBackground {
+            save()
+        }
+    }
+    
+    @objc private func applicationWillTerminate(notfication: NSNotification) {
+        if self.shouldSaveWhenApplicationWillTerminate {
+            save()
+        }
+    }
+    
+}

--- a/Sources/PersistenceError.swift
+++ b/Sources/PersistenceError.swift
@@ -4,6 +4,5 @@ public enum PersistenceError: Error {
     
     case objectModelNotFound
     case persistentStoreDescriptionMissing
-    case threadConfinementViolation
     
 }

--- a/Sources/PersistenceError.swift
+++ b/Sources/PersistenceError.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public enum PersistenceError: Error {
+    
+    case objectModelNotFound
+    case persistentStoreDescriptionMissing
+    case threadConfinementViolation
+    
+}

--- a/Sources/PersistentStoreDescription+RLBErrorRecovery.swift
+++ b/Sources/PersistentStoreDescription+RLBErrorRecovery.swift
@@ -1,0 +1,54 @@
+import Foundation
+import CoreData
+
+public extension NSPersistentStoreDescription {
+    
+    // MARK: - Types
+    
+    private struct AssociatedKeys {
+        
+        // MARK: - Properties
+        
+        static var errorRecoveryPolicy: UInt8 = 0
+        
+    }
+    
+    // MARK: - Properties
+    
+    var errorRecoveryPolicy: ErrorRecoveryPolicy {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.errorRecoveryPolicy) as? ErrorRecoveryPolicy ?? .fail
+        }
+        
+        set(newValue) {
+            objc_setAssociatedObject(self, &AssociatedKeys.errorRecoveryPolicy, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+    
+    // MARK: - Internal methods
+    
+    func attemptRecovery() {
+        let fileManager = FileManager.default
+        
+        guard let url = url, fileManager.fileExists(atPath: url.path) else {
+            return
+        }
+        
+        switch errorRecoveryPolicy {
+        case .deleteStore:
+            try? fileManager.removeItem(at: url)
+            
+        case let .backupStore(backupURL):
+            if fileManager.fileExists(atPath: backupURL.path) {
+                try? fileManager.removeItem(at: backupURL)
+            }
+            
+            try? fileManager.moveItem(at: url, to: backupURL)
+            
+        case .fail:
+            // Do not attempt to recover.
+            break
+        }
+    }
+    
+}

--- a/Tests/Model/TestModel.xcdatamodeld/TestModel.xcdatamodel/contents
+++ b/Tests/Model/TestModel.xcdatamodeld/TestModel.xcdatamodel/contents
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14492.1" systemVersion="18G87" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="TestEntity" representedClassName="TestEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="TestEntity" positionX="-63" positionY="-18" width="128" height="60"/>
+    </elements>
+</model>

--- a/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
+++ b/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
@@ -22,22 +22,22 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         let instantiationExpectation = self.expectation(description: "Instantiation")
         
-        let optionalPersistenceController = PersistenceController(model: model, storeDescriptions: [storeDescription]) { error in
-            if error != nil {
-                assertionFailure("Failed to create in-memory store.")
+        do {
+            self.persistenceController = try PersistenceController(model: model, storeDescriptions: [storeDescription]) { error in
+                if error != nil {
+                    assertionFailure("Failed to create in-memory store.")
+                }
+                
+                instantiationExpectation.fulfill()
             }
-            
+        } catch {
+            assertionFailure("Failed to instantiat persistence controller.")
             instantiationExpectation.fulfill()
         }
         
         waitForExpectations(timeout: 5.0)
         
-        guard let persistenceController = optionalPersistenceController else {
-            assertionFailure("Failed to instantiat persistence controller.")
-            return
-        }
-        
-        let mainContext = persistenceController.mainContext
+        let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
             let firstEntity = NSEntityDescription.insertNewObject(forEntityName: String(describing: TestEntity.self), into: mainContext) as! TestEntity
@@ -56,9 +56,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
             fifthEntity.name = "fifth"
         }
         
-        persistenceController.save()
-        
-        self.persistenceController = persistenceController
+        self.persistenceController.save()
     }
     
     // MARK: - Tests

--- a/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
+++ b/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
@@ -1,0 +1,412 @@
+import XCTest
+import CoreData
+@testable import PusherPlatform
+
+class NSManagedObjectContext_PersistenceTests: XCTestCase {
+    
+    // MARK: - Properties
+    
+    var persistenceController: PersistenceController!
+    
+    // MARK: - Tests lifecycle
+    
+    override func setUp() {
+        super.setUp()
+        
+        guard let url = Bundle(for: type(of: self)).url(forResource: "TestModel", withExtension: "momd"), let model = NSManagedObjectModel(contentsOf: url) else {
+            assertionFailure("Unable to locate test model.")
+            return
+        }
+        
+        let storeDescription = NSPersistentStoreDescription(inMemoryPersistentStoreDescription: ())
+        
+        let instantiationExpectation = self.expectation(description: "Instantiation")
+        
+        let optionalPersistenceController = PersistenceController(model: model, storeDescriptions: [storeDescription]) { error in
+            if error != nil {
+                assertionFailure("Failed to create in-memory store.")
+            }
+            
+            instantiationExpectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5.0)
+        
+        guard let persistenceController = optionalPersistenceController else {
+            assertionFailure("Failed to instantiat persistence controller.")
+            return
+        }
+        
+        let mainContext = persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let firstEntity = NSEntityDescription.insertNewObject(forEntityName: String(describing: TestEntity.self), into: mainContext) as! TestEntity
+            firstEntity.name = "first"
+            
+            let secondEntity = NSEntityDescription.insertNewObject(forEntityName: String(describing: TestEntity.self), into: mainContext) as! TestEntity
+            secondEntity.name = "second"
+            
+            let thirdEntity = NSEntityDescription.insertNewObject(forEntityName: String(describing: TestEntity.self), into: mainContext) as! TestEntity
+            thirdEntity.name = "third"
+            
+            let fourthEntity = NSEntityDescription.insertNewObject(forEntityName: String(describing: TestEntity.self), into: mainContext) as! TestEntity
+            fourthEntity.name = "fourth"
+            
+            let fifthEntity = NSEntityDescription.insertNewObject(forEntityName: String(describing: TestEntity.self), into: mainContext) as! TestEntity
+            fifthEntity.name = "fifth"
+        }
+        
+        persistenceController.save()
+        
+        self.persistenceController = persistenceController
+    }
+    
+    // MARK: - Tests
+    
+    func testShouldCreateNewEntity() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let _ = mainContext.create(TestEntity.self)
+            
+            let countRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
+            let count = try! mainContext.count(for: countRequest)
+            
+            XCTAssertEqual(count, 6)
+        }
+    }
+    
+    func testShouldDeleteEntityWithobjectID() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let fetchRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
+            fetchRequest.predicate = NSPredicate(format: "name = %@", "fourth")
+            fetchRequest.fetchLimit = 1
+            
+            let entity = try! mainContext.fetch(fetchRequest).first!
+            
+            XCTAssertFalse(entity.isDeleted)
+            
+            mainContext.delete(with: entity.objectID)
+            
+            XCTAssertTrue(entity.isDeleted)
+            
+            let countRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
+            let count = try! mainContext.count(for: countRequest)
+            
+            XCTAssertEqual(count, 4)
+        }
+    }
+    
+    func testShouldDeleteAllEntities() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            mainContext.deleteAll(TestEntity.self)
+            
+            let countRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
+            let count = try! mainContext.count(for: countRequest)
+            
+            XCTAssertEqual(count, 0)
+        }
+    }
+    
+    func testShouldDeleteAllEntitiesMatchingPredicate() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let predicate = NSPredicate(format: "name = %@ OR name = %@", "second", "fifth")
+            
+            mainContext.deleteAll(TestEntity.self, predicate: predicate)
+            
+            let countRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
+            let count = try! mainContext.count(for: countRequest)
+            
+            XCTAssertEqual(count, 3)
+        }
+    }
+    
+    func testShouldDeleteAllEntitiesMatchingPredicateFormat() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            mainContext.deleteAll(TestEntity.self, predicateFormat: "name = %@ OR name = %@ OR name = %@", "first", "second", "fifth")
+            
+            let countRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
+            let count = try! mainContext.count(for: countRequest)
+            
+            XCTAssertEqual(count, 2)
+        }
+    }
+    
+    func testShouldFetchRandomEntity() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let entity = mainContext.fetch(TestEntity.self)
+            
+            XCTAssertNotNil(entity)
+        }
+    }
+    
+    func testShouldFetchEntityUsingSortDescriptors() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
+            let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor])
+            
+            XCTAssertEqual(entity?.name, "third")
+        }
+    }
+    
+    func testShouldFetchEntityMatchingPredicate() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let predicate = NSPredicate(format: "name = %@", "second")
+            let entity = mainContext.fetch(TestEntity.self, predicate: predicate)
+            
+            XCTAssertEqual(entity?.name, "second")
+        }
+    }
+    
+    func testShouldFetchEntityMatchingPredicateFormat() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let entity = mainContext.fetch(TestEntity.self, predicateFormat: "name = %@", "fifth")
+            
+            XCTAssertEqual(entity?.name, "fifth")
+        }
+    }
+    
+    func testShouldFetchEntityUsingSortDescriptorsAndPredicate() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
+            let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor], predicate: predicate)
+            
+            XCTAssertEqual(entity?.name, "fourth")
+        }
+    }
+    
+    func testShouldFetchEntityUsingSortDescriptorsAndPredicateFormat() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
+            let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor], predicateFormat: "name BEGINSWITH[c] %@", "f")
+            
+            XCTAssertEqual(entity?.name, "fifth")
+        }
+    }
+    
+    func testShouldFetchAllEntities() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let entities = mainContext.fetchAll(TestEntity.self)
+            
+            XCTAssertEqual(entities.count, 5)
+        }
+    }
+    
+    func testShouldFetchAllEntitiesUsingSortDescriptors() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
+            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor])
+            
+            XCTAssertEqual(entities.count, 5)
+            
+            XCTAssertEqual(entities[0].name, "fifth")
+            XCTAssertEqual(entities[1].name, "first")
+            XCTAssertEqual(entities[2].name, "fourth")
+            XCTAssertEqual(entities[3].name, "second")
+            XCTAssertEqual(entities[4].name, "third")
+        }
+    }
+    
+    func testShouldFetchAllEntitiesUsingFetchLimit() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let entities = mainContext.fetchAll(TestEntity.self, fetchLimit: 2)
+            
+            XCTAssertEqual(entities.count, 2)
+        }
+    }
+    
+    func testShouldFetchAllEntitiesMatchingPredicate() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let entities = mainContext.fetchAll(TestEntity.self, predicate: predicate)
+            
+            XCTAssertEqual(entities.count, 3)
+        }
+    }
+    
+    func testShouldFetchAllEntitiesMatchingPredicateFormat() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let entities = mainContext.fetchAll(TestEntity.self, predicateFormat: "name ENDSWITH[c] %@", "h")
+            
+            XCTAssertEqual(entities.count, 2)
+        }
+    }
+    
+    func testShouldFetchAllEntitiesUsingSortDescriptorsAndFetchLimit() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
+            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2)
+            
+            XCTAssertEqual(entities.count, 2)
+            
+            XCTAssertEqual(entities[0].name, "third")
+            XCTAssertEqual(entities[1].name, "second")
+        }
+    }
+    
+    func testShouldFetchAllEntitiesUsingSortDescriptorsAndPredicate() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
+            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], predicate: predicate)
+            
+            XCTAssertEqual(entities.count, 3)
+            
+            XCTAssertEqual(entities[0].name, "fourth")
+            XCTAssertEqual(entities[1].name, "first")
+            XCTAssertEqual(entities[2].name, "fifth")
+        }
+    }
+    
+    func testShouldFetchAllEntitiesUsingSortDescriptorsAndPredicateFormat() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
+            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], predicateFormat: "name BEGINSWITH[c] %@", "f")
+            
+            XCTAssertEqual(entities.count, 3)
+            
+            XCTAssertEqual(entities[0].name, "fifth")
+            XCTAssertEqual(entities[1].name, "first")
+            XCTAssertEqual(entities[2].name, "fourth")
+        }
+    }
+    
+    func testShouldFetchAllEntitiesMatchingFetchLimitAndPredicate() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let entities = mainContext.fetchAll(TestEntity.self, fetchLimit: 2, predicate: predicate)
+            
+            XCTAssertEqual(entities.count, 2)
+            
+            let acceptableResults: Set = ["first", "fourth", "fifth"]
+            
+            guard let firstResultName = entities.first?.name, let secondResultName = entities.last?.name else {
+                XCTFail("Fetch results should contain excatly two entities.")
+                return
+            }
+            
+            XCTAssertTrue(acceptableResults.contains(firstResultName))
+            XCTAssertTrue(acceptableResults.contains(secondResultName))
+        }
+    }
+    
+    func testShouldFetchAllEntitiesMatchingFetchLimitAndPredicateFormat() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let entities = mainContext.fetchAll(TestEntity.self, fetchLimit: 2, predicateFormat: "name CONTAINS[c] %@", "h")
+            
+            XCTAssertEqual(entities.count, 2)
+            
+            let acceptableResults: Set = ["third", "fourth", "fifth"]
+            
+            guard let firstResultName = entities.first?.name, let secondResultName = entities.last?.name else {
+                XCTFail("Fetch results should contain excatly two entities.")
+                return
+            }
+            
+            XCTAssertTrue(acceptableResults.contains(firstResultName))
+            XCTAssertTrue(acceptableResults.contains(secondResultName))
+        }
+    }
+    
+    func testShouldFetchAllEntitiesUsingSortDescriptorsFetchLimitAndPredicate() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
+            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2, predicate: predicate)
+            
+            XCTAssertEqual(entities.count, 2)
+            
+            XCTAssertEqual(entities[0].name, "fourth")
+            XCTAssertEqual(entities[1].name, "first")
+        }
+    }
+    
+    func testShouldFetchAllEntitiesUsingSortDescriptorsFetchLimitAndPredicateFormat() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
+            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2, predicateFormat: "name CONTAINS[c] %@", "h")
+            
+            XCTAssertEqual(entities.count, 2)
+            
+            XCTAssertEqual(entities[0].name, "third")
+            XCTAssertEqual(entities[1].name, "fourth")
+        }
+    }
+    
+    func testShouldCountAllEntities() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let count = mainContext.count(TestEntity.self)
+            
+            XCTAssertEqual(count, 5)
+        }
+    }
+    
+    func testShouldCountAllEntitiesMatchingPredicate() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let count = mainContext.count(TestEntity.self, predicate: predicate)
+            
+            XCTAssertEqual(count, 3)
+        }
+    }
+    
+    func testShouldCountAllEntitiesMatchingPredicateFormat() {
+        let mainContext = self.persistenceController.mainContext
+        
+        mainContext.performAndWait {
+            let count = mainContext.count(TestEntity.self, predicateFormat: "name CONTAINS[c] %@", "o")
+            
+            XCTAssertEqual(count, 2)
+        }
+    }
+    
+}

--- a/Tests/Persistence/NSPersistentStoreDescription_RecoveryTests.swift
+++ b/Tests/Persistence/NSPersistentStoreDescription_RecoveryTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import CoreData
+@testable import PusherPlatform
+
+class NSPersistentStoreDescription_RecoveryTests: XCTestCase {
+    
+    // MARK: - Properties
+    
+    var url: URL!
+    var moveURL: URL!
+    
+    // MARK: - Tests lifecycle
+    
+    override func setUp() {
+        super.setUp()
+        
+        self.url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("test.sqlite")
+        self.moveURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("movedTest.sqlite")
+        
+        FileManager.default.createFile(atPath: self.url.path, contents: nil, attributes: nil)
+    }
+    
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: self.url)
+        try? FileManager.default.removeItem(at: self.moveURL)
+    }
+    
+    // MARK: - Tests
+    
+    func testShouldNotAttemptToRecoverForFailPolicy() {
+        let storeDescription =  NSPersistentStoreDescription(sqlitePersistentStoreDescriptionWithURL: self.url, errorRecoveryPolicy: .fail)
+        storeDescription.attemptRecovery()
+        
+        XCTAssertTrue(FileManager.default.fileExists(atPath: self.url.path))
+    }
+    
+    func testShouldRecoverForDeleteStorePolicy() {
+        let storeDescription =  NSPersistentStoreDescription(sqlitePersistentStoreDescriptionWithURL: self.url, errorRecoveryPolicy: .deleteStore)
+        storeDescription.attemptRecovery()
+        
+        XCTAssertFalse(FileManager.default.fileExists(atPath: self.url.path))
+    }
+    
+    func testShouldRecoverForBackupStorePolicy() {
+        let storeDescription =  NSPersistentStoreDescription(sqlitePersistentStoreDescriptionWithURL: self.url, errorRecoveryPolicy: .backupStore(self.moveURL))
+        storeDescription.attemptRecovery()
+        
+        XCTAssertFalse(FileManager.default.fileExists(atPath: self.url.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: self.moveURL.path))
+    }
+    
+}

--- a/Tests/Persistence/NSPersistentStoreDescription_StoreTypesTests.swift
+++ b/Tests/Persistence/NSPersistentStoreDescription_StoreTypesTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import CoreData
+@testable import PusherPlatform
+
+class NSPersistentStoreDescription_StoreTypesTests: XCTestCase {
+    
+    // MARK: - Tests
+    
+    func testShouldInitializeInMemoryStoreDescriptionWithDefaultValues() {
+        let storeDescription = NSPersistentStoreDescription(inMemoryPersistentStoreDescription: ())
+        
+        XCTAssertEqual(storeDescription.type, NSInMemoryStoreType)
+        XCTAssertEqual(storeDescription.url, URL(string: "file:///dev/null"))
+        XCTAssertNil(storeDescription.configuration)
+        XCTAssertTrue(storeDescription.shouldAddStoreAsynchronously)
+        XCTAssertTrue(storeDescription.shouldInferMappingModelAutomatically)
+    }
+    
+    func testShouldInitializeInMemoryStoreDescriptionWithDefaultValuesForEmptyConfiguration() {
+        let storeDescription = NSPersistentStoreDescription(inMemoryPersistentStoreDescriptionForConfiguration: nil)
+        
+        XCTAssertEqual(storeDescription.type, NSInMemoryStoreType)
+        XCTAssertEqual(storeDescription.url, URL(string: "file:///dev/null"))
+        XCTAssertNil(storeDescription.configuration)
+        XCTAssertTrue(storeDescription.shouldAddStoreAsynchronously)
+        XCTAssertTrue(storeDescription.shouldInferMappingModelAutomatically)
+    }
+    
+    func testShouldInitializeInMemoryStoreDescriptionWithCustomValues() {
+        let storeDescription = NSPersistentStoreDescription(inMemoryPersistentStoreDescriptionForConfiguration: "testConfiguration",
+                                                            shouldAddStoreAsynchronously: false,
+                                                            shouldInferMappingModelAutomatically: false)
+        
+        XCTAssertEqual(storeDescription.type, NSInMemoryStoreType)
+        XCTAssertEqual(storeDescription.url, URL(string: "file:///dev/null"))
+        XCTAssertEqual(storeDescription.configuration, "testConfiguration")
+        XCTAssertFalse(storeDescription.shouldAddStoreAsynchronously)
+        XCTAssertFalse(storeDescription.shouldInferMappingModelAutomatically)
+    }
+    
+    func testShouldInitializeSQLiteStoreDescriptionWithDefaultValues() {
+        let testURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        
+        let storeDescription = NSPersistentStoreDescription(sqlitePersistentStoreDescriptionWithURL: testURL, errorRecoveryPolicy: .deleteStore)
+        
+        XCTAssertEqual(storeDescription.type, NSSQLiteStoreType)
+        XCTAssertEqual(storeDescription.url, testURL)
+        XCTAssertEqual(storeDescription.errorRecoveryPolicy, ErrorRecoveryPolicy.deleteStore)
+        XCTAssertNil(storeDescription.configuration)
+        XCTAssertFalse(storeDescription.isReadOnly)
+        XCTAssertTrue(storeDescription.shouldAddStoreAsynchronously)
+        XCTAssertTrue(storeDescription.shouldMigrateStoreAutomatically)
+        XCTAssertTrue(storeDescription.shouldInferMappingModelAutomatically)
+        XCTAssertEqual(storeDescription.sqlitePragmas["journal_mode"] as? String, SQLiteJournalMode.writeAheadLog.rawValue)
+    }
+    
+    func testShouldInitializeSQLiteStoreDescriptionWithCustomValues() {
+        let testURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        
+        let storeDescription = NSPersistentStoreDescription(sqlitePersistentStoreDescriptionWithURL: testURL,
+                                                            errorRecoveryPolicy: .deleteStore,
+                                                            configuration: "testConfiguration",
+                                                            isReadOnly: true,
+                                                            journalMode: .off,
+                                                            shouldAddStoreAsynchronously: false,
+                                                            shouldMigrateStoreAutomatically: false,
+                                                            shouldInferMappingModelAutomatically: false)
+        
+        XCTAssertEqual(storeDescription.type, NSSQLiteStoreType)
+        XCTAssertEqual(storeDescription.url, testURL)
+        XCTAssertEqual(storeDescription.errorRecoveryPolicy, ErrorRecoveryPolicy.deleteStore)
+        XCTAssertEqual(storeDescription.configuration, "testConfiguration")
+        XCTAssertTrue(storeDescription.isReadOnly)
+        XCTAssertFalse(storeDescription.shouldAddStoreAsynchronously)
+        XCTAssertFalse(storeDescription.shouldMigrateStoreAutomatically)
+        XCTAssertFalse(storeDescription.shouldInferMappingModelAutomatically)
+        XCTAssertEqual(storeDescription.sqlitePragmas["journal_mode"] as? String, SQLiteJournalMode.off.rawValue)
+    }
+    
+}

--- a/Tests/Persistence/PersistenceControllerTests.swift
+++ b/Tests/Persistence/PersistenceControllerTests.swift
@@ -1,0 +1,347 @@
+import XCTest
+import CoreData
+@testable import PusherPlatform
+
+import XCTest
+
+class PersistenceControllerTests: XCTestCase {
+    
+    // MARK: - Properties
+    
+    let testStoreDescription = NSPersistentStoreDescription(inMemoryPersistentStoreDescription: ())
+    var testModel: NSManagedObjectModel!
+    var persistenceController: PersistenceController!
+    
+    // MARK: - Tests lifecycle
+    
+    override func setUp() {
+        super.setUp()
+        
+        guard let url = Bundle(for: type(of: self)).url(forResource: "TestModel", withExtension: "momd"), let model = NSManagedObjectModel(contentsOf: url) else {
+            assertionFailure("Unable to locate test model.")
+            return
+        }
+        
+        self.testModel = model
+        
+        let instantiationExpectation = self.expectation(description: "Instantiation")
+        
+        let optionalPersistenceController = PersistenceController(model: self.testModel, storeDescriptions: [self.testStoreDescription], logger: PPDefaultLogger()) { error in
+            if error != nil {
+                assertionFailure("Failed to create in-memory store.")
+            }
+            
+            instantiationExpectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 5.0)
+        
+        guard let persistenceController = optionalPersistenceController else {
+            assertionFailure("Failed to instantiat persistence controller.")
+            return
+        }
+        
+        self.persistenceController = persistenceController
+    }
+    
+    // MARK: - Tests
+    
+    func testShouldNotInstantiatePersistenceControllerWithoutStoreDescriptions() {
+        let persistenceController = PersistenceController(storeDescriptions: []) { error in
+            guard let error = error as? PersistenceError else {
+                XCTFail("Missing error object.")
+                return
+            }
+            
+            XCTAssertEqual(error, PersistenceError.persistentStoreDescriptionMissing)
+        }
+        
+        XCTAssertNil(persistenceController)
+    }
+    
+    func testShouldNotInstantiatePersistenceControllerFromThreadOtherThanMainThread() {
+        let expectation = self.expectation(description: "Asynchronous instantiation")
+        
+        DispatchQueue.global(qos: .background).async { [weak self] in
+            guard let self = self else { return }
+            
+            let persistenceController = PersistenceController(storeDescriptions: [self.testStoreDescription]) { error in
+                guard let error = error as? PersistenceError else {
+                    XCTFail("Missing error object.")
+                    return
+                }
+                
+                XCTAssertEqual(error, PersistenceError.threadConfinementViolation)
+            }
+            
+            XCTAssertNil(persistenceController)
+            
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testShouldHaveModelWithCorrectNumberOfEntities() {
+        XCTAssertEqual(self.persistenceController.model, self.testModel)
+        XCTAssertEqual(self.persistenceController.model.entities.count, 1)
+    }
+    
+    func testShouldHaveMainContextWithCorrectSetup() {
+        let privateContext = self.persistenceController.mainContext.parent
+        
+        XCTAssertNotNil(self.persistenceController.mainContext)
+        XCTAssertEqual(self.persistenceController.mainContext.concurrencyType, NSManagedObjectContextConcurrencyType.mainQueueConcurrencyType)
+        XCTAssertTrue(self.persistenceController.mainContext.automaticallyMergesChangesFromParent)
+        XCTAssertNotNil(privateContext)
+    }
+    
+    func testShouldHavePrivateContextWithCorrectSetup() {
+        let privateContext = self.persistenceController.mainContext.parent
+        
+        XCTAssertNotNil(privateContext)
+        XCTAssertNotNil(privateContext?.persistentStoreCoordinator)
+        XCTAssertEqual(privateContext?.concurrencyType, NSManagedObjectContextConcurrencyType.privateQueueConcurrencyType)
+        XCTAssertEqual(privateContext?.mergePolicy as? NSMergePolicy, NSMergeByPropertyObjectTrumpMergePolicy as? NSMergePolicy)
+        XCTAssertNil(privateContext?.parent)
+    }
+    
+    func testShouldHaveCorrectDefaultApplicationLifecycleSettings() {
+        XCTAssertFalse(self.persistenceController.shouldSaveWhenApplicationWillResignActive)
+        XCTAssertTrue(self.persistenceController.shouldSaveWhenApplicationDidEnterBackground)
+        XCTAssertTrue(self.persistenceController.shouldSaveWhenApplicationWillTerminate)
+    }
+    
+    func testShouldHaveAnInstanceOfLogger() {
+        XCTAssertNotNil(self.persistenceController.logger)
+    }
+    
+    func testPersistentStoreCoordinatorShouldHaveCorrectNumberOfStores() {
+        XCTAssertEqual(self.persistenceController.storeCoordinator.persistentStores.count, 1)
+        
+        guard let persistentStore = self.persistenceController.storeCoordinator.persistentStores.first else {
+            XCTFail("Persistent store coordinator should have exactly one store.")
+            return
+        }
+        
+        XCTAssertEqual(persistentStore.type, NSInMemoryStoreType)
+    }
+    
+    func testCreateBackgroundContextWithCorrectSetup() {
+        let privateContext = self.persistenceController.mainContext.parent
+        
+        let expectation = self.expectation(description: "Background task")
+        
+        self.persistenceController.performBackgroundTask { backgroundContext in
+            XCTAssertEqual(backgroundContext.parent, privateContext)
+            XCTAssertEqual(backgroundContext.concurrencyType, NSManagedObjectContextConcurrencyType.privateQueueConcurrencyType)
+            XCTAssertTrue(backgroundContext.automaticallyMergesChangesFromParent)
+            
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testShouldAutomaticallyPropagateChangesFromPrivateContextToMainContextWithoutSave() {
+        let mainContext = self.persistenceController.mainContext
+        
+        guard let privateContext = mainContext.parent else {
+            XCTFail("Persistence controller should have a private context.")
+            return
+        }
+        
+        privateContext.performAndWait {
+            let testEntity = privateContext.create(TestEntity.self)
+            testEntity.name = "privateContextTest"
+            
+            XCTAssertEqual(privateContext.count(TestEntity.self), 1)
+            XCTAssertTrue(privateContext.hasChanges)
+        }
+        
+        mainContext.performAndWait {
+            XCTAssertFalse(mainContext.hasChanges)
+            XCTAssertEqual(mainContext.count(TestEntity.self), 1)
+            
+            guard let result = mainContext.fetch(TestEntity.self) else {
+                XCTFail("Main context should contain test entity.")
+                return
+            }
+            
+            XCTAssertEqual(result.name, "privateContextTest")
+        }
+    }
+    
+    func testShouldNotAutomaticallyPropagateChangesFromMainContextToPrivateContextWithoutSave() {
+        let mainContext = self.persistenceController.mainContext
+        
+        guard let privateContext = mainContext.parent else {
+            XCTFail("Persistence controller should have a private context.")
+            return
+        }
+        
+        mainContext.performAndWait {
+            let _ = mainContext.create(TestEntity.self)
+            
+            XCTAssertEqual(mainContext.count(TestEntity.self), 1)
+            XCTAssertTrue(mainContext.hasChanges)
+        }
+        
+        privateContext.performAndWait {
+            XCTAssertFalse(privateContext.hasChanges)
+            XCTAssertEqual(privateContext.count(TestEntity.self), 0)
+        }
+    }
+    
+    func testShouldPropagateChangesFromMainContextToPrivateContextAfterSave() {
+        let mainContext = self.persistenceController.mainContext
+        
+        guard let privateContext = mainContext.parent else {
+            XCTFail("Persistence controller should have a private context.")
+            return
+        }
+        
+        mainContext.performAndWait {
+            let testEntity = mainContext.create(TestEntity.self)
+            testEntity.name = "mainContextTest"
+            
+            XCTAssertTrue(mainContext.hasChanges)
+            
+            try? mainContext.save()
+            
+            XCTAssertEqual(mainContext.count(TestEntity.self), 1)
+            XCTAssertFalse(mainContext.hasChanges)
+        }
+        
+        privateContext.performAndWait {
+            XCTAssertTrue(privateContext.hasChanges)
+            XCTAssertEqual(privateContext.count(TestEntity.self), 1)
+            
+            guard let result = privateContext.fetch(TestEntity.self) else {
+                XCTFail("Private context should contain test entity.")
+                return
+            }
+            
+            XCTAssertEqual(result.name, "mainContextTest")
+        }
+    }
+    
+    func testShouldCorrectlyPropagateChangesFromBackgroundContextToOtherContexts() {
+        let mainContext = self.persistenceController.mainContext
+        
+        guard let privateContext = mainContext.parent else {
+            XCTFail("Persistence controller should have a private context.")
+            return
+        }
+        
+        let backgroundTaskExpectation = self.expectation(description: "Background task")
+        
+        self.persistenceController.performBackgroundTask { backgroundContext in
+            XCTAssertFalse(backgroundContext.hasChanges)
+            
+            let testEntity = backgroundContext.create(TestEntity.self)
+            testEntity.name = "backgroundContextTest"
+            
+            XCTAssertTrue(backgroundContext.hasChanges)
+            
+            try? backgroundContext.save()
+            
+            XCTAssertFalse(backgroundContext.hasChanges)
+            
+            backgroundTaskExpectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+        
+        privateContext.performAndWait {
+            XCTAssertTrue(privateContext.hasChanges)
+            XCTAssertEqual(privateContext.count(TestEntity.self), 1)
+            
+            guard let result = privateContext.fetch(TestEntity.self) else {
+                XCTFail("Private context should contain test entity.")
+                return
+            }
+            
+            XCTAssertEqual(result.name, "backgroundContextTest")
+        }
+        
+        mainContext.performAndWait {
+            XCTAssertFalse(mainContext.hasChanges)
+            XCTAssertEqual(mainContext.count(TestEntity.self), 1)
+            
+            guard let result = mainContext.fetch(TestEntity.self) else {
+                XCTFail("Main context should contain test entity.")
+                return
+            }
+            
+            XCTAssertEqual(result.name, "backgroundContextTest")
+        }
+    }
+    
+    func testShouldSaveWhenThereArePendingChangesInTheMainContext() {
+        let mainContext = self.persistenceController.mainContext
+        
+        guard let privateContext = mainContext.parent else {
+            XCTFail("Persistence controller should have a private context.")
+            return
+        }
+        
+        privateContext.performAndWait {
+            XCTAssertFalse(privateContext.hasChanges)
+            XCTAssertEqual(privateContext.count(TestEntity.self), 0)
+        }
+        
+        mainContext.performAndWait {
+            let _ = mainContext.create(TestEntity.self)
+            
+            XCTAssertTrue(mainContext.hasChanges)
+            XCTAssertEqual(mainContext.count(TestEntity.self), 1)
+        }
+        
+        persistenceController.save()
+        
+        mainContext.performAndWait {
+            XCTAssertFalse(mainContext.hasChanges)
+            XCTAssertEqual(mainContext.count(TestEntity.self), 1)
+        }
+        
+        privateContext.performAndWait {
+            XCTAssertFalse(privateContext.hasChanges)
+            XCTAssertEqual(privateContext.count(TestEntity.self), 1)
+        }
+    }
+    
+    func testShouldSaveWhenThereArePendingChangesInThePrivateContext() {
+        let mainContext = self.persistenceController.mainContext
+        
+        guard let privateContext = mainContext.parent else {
+            XCTFail("Persistence controller should have a private context.")
+            return
+        }
+        
+        mainContext.performAndWait {
+            XCTAssertFalse(mainContext.hasChanges)
+            XCTAssertEqual(mainContext.count(TestEntity.self), 0)
+        }
+        
+        privateContext.performAndWait {
+            let _ = privateContext.create(TestEntity.self)
+            
+            XCTAssertTrue(privateContext.hasChanges)
+            XCTAssertEqual(privateContext.count(TestEntity.self), 1)
+        }
+        
+        persistenceController.save()
+        
+        mainContext.performAndWait {
+            XCTAssertFalse(mainContext.hasChanges)
+            XCTAssertEqual(mainContext.count(TestEntity.self), 1)
+        }
+        
+        privateContext.performAndWait {
+            XCTAssertFalse(privateContext.hasChanges)
+            XCTAssertEqual(privateContext.count(TestEntity.self), 1)
+        }
+    }
+    
+}

--- a/Tests/Persistence/PersistenceControllerTests.swift
+++ b/Tests/Persistence/PersistenceControllerTests.swift
@@ -45,29 +45,9 @@ class PersistenceControllerTests: XCTestCase {
     // MARK: - Tests
     
     func testShouldNotInstantiatePersistenceControllerWithoutStoreDescriptions() {
-        XCTAssertThrowsError(try PersistenceController(storeDescriptions: [])) { error in
+        XCTAssertThrowsError(try PersistenceController(model: self.testModel, storeDescriptions: [])) { error in
             XCTAssertEqual(error as? PersistenceError, PersistenceError.persistentStoreDescriptionMissing)
         }
-    }
-    
-    func testShouldNotInstantiatePersistenceControllerFromThreadOtherThanMainThread() {
-        let expectation = self.expectation(description: "Asynchronous instantiation")
-        
-        DispatchQueue.global(qos: .background).async { [weak self] in
-            guard let self = self else { return }
-            
-            do {
-                // This should be implemented using a simple XCTAssertThrowsError(expression:, errorHandler:), but due to a compiler issue it cannot be at the moment. Please see Swift issue SR-487 for more details.
-                XCTAssertThrowsError(try PersistenceController(storeDescriptions: [self.testStoreDescription]))
-                let _ = try PersistenceController(storeDescriptions: [self.testStoreDescription])
-            } catch {
-                XCTAssertEqual(error as? PersistenceError, PersistenceError.threadConfinementViolation)
-            }
-            
-            expectation.fulfill()
-        }
-        
-        waitForExpectations(timeout: 1.0)
     }
     
     func testShouldHaveModelWithCorrectNumberOfEntities() {


### PR DESCRIPTION
### What?

- Persistence controller that helps to manage Core Data stack.
- NSPersistentStoreDescription convenience initialisers.
- NSManagedObjectContext helper methods.

### Why?

Introducing a reusable Core Data stack that is required for Chatkit 2.0.0 persistence layer.

----

CC @pusher/sigsdk
