### PR TITLE
Ability fo fire faults of fetched entities

### DIFF
--- a/Sources/NSManagedObjectContext+Persistence.swift
+++ b/Sources/NSManagedObjectContext+Persistence.swift
@@ -35,22 +35,23 @@ public extension NSManagedObjectContext {
         deleteAll(entity, predicate: predicate)
     }
     
-    func fetch<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, predicate: NSPredicate? = nil) -> T? {
-        return fetchAll(entity, sortDescriptors: sortDescriptors, predicate: predicate).first
+    func fetch<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortDescriptors: [NSSortDescriptor]? = nil, predicate: NSPredicate? = nil) -> T? {
+        return fetchAll(entity, withRelationships: relationships, sortDescriptors: sortDescriptors, predicate: predicate).first
     }
     
-    func fetch<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, predicateFormat: String, _ predicateArguments: CVarArg...) -> T? {
+    func fetch<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortDescriptors: [NSSortDescriptor]? = nil, predicateFormat: String, _ predicateArguments: CVarArg...) -> T? {
         var predicate: NSPredicate? = nil
         
         withVaList(predicateArguments) { arguments in
             predicate = NSPredicate(format: predicateFormat, arguments: arguments)
         }
         
-        return fetch(entity, sortDescriptors: sortDescriptors, predicate: predicate)
+        return fetch(entity, withRelationships: relationships, sortDescriptors: sortDescriptors, predicate: predicate)
     }
     
-    func fetchAll<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, fetchLimit: Int = 0, predicate: NSPredicate? = nil) -> [T] {
+    func fetchAll<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortDescriptors: [NSSortDescriptor]? = nil, fetchLimit: Int = 0, predicate: NSPredicate? = nil) -> [T] {
         let fetchRequest = NSFetchRequest<T>(entityName: String(describing: T.self))
+        fetchRequest.relationshipKeyPathsForPrefetching = relationships
         fetchRequest.sortDescriptors = sortDescriptors
         fetchRequest.fetchLimit = fetchLimit
         fetchRequest.predicate = predicate
@@ -58,14 +59,14 @@ public extension NSManagedObjectContext {
         return (try? fetch(fetchRequest)) ?? [T]()
     }
     
-    func fetchAll<T: NSManagedObject>(_ entity: T.Type, sortDescriptors: [NSSortDescriptor]? = nil, fetchLimit: Int = 0, predicateFormat: String, _ predicateArguments: CVarArg...) -> [T] {
+    func fetchAll<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortDescriptors: [NSSortDescriptor]? = nil, fetchLimit: Int = 0, predicateFormat: String, _ predicateArguments: CVarArg...) -> [T] {
         var predicate: NSPredicate? = nil
         
         withVaList(predicateArguments) { arguments in
             predicate = NSPredicate(format: predicateFormat, arguments: arguments)
         }
         
-        return fetchAll(entity, sortDescriptors: sortDescriptors, fetchLimit: fetchLimit, predicate: predicate)
+        return fetchAll(entity, withRelationships: relationships, sortDescriptors: sortDescriptors, fetchLimit: fetchLimit, predicate: predicate)
     }
     
     func count<T: NSManagedObject>(_ entity: T.Type, predicate: NSPredicate? = nil) -> Int {

--- a/Sources/NSManagedObjectContext+Persistence.swift
+++ b/Sources/NSManagedObjectContext+Persistence.swift
@@ -18,10 +18,8 @@ public extension NSManagedObjectContext {
     }
     
     func deleteAll<T: NSManagedObject>(_ entity: T.Type, filteredBy predicate: NSPredicate? = nil) {
-        let objects = fetchAll(entity, filteredBy: predicate)
-        
-        for object in objects {
-            delete(object)
+        fetchAll(entity, filteredBy: predicate).forEach {
+            delete($0)
         }
     }
     

--- a/Sources/NSManagedObjectContext+Persistence.swift
+++ b/Sources/NSManagedObjectContext+Persistence.swift
@@ -17,73 +17,73 @@ public extension NSManagedObjectContext {
         delete(object)
     }
     
-    func deleteAll<T: NSManagedObject>(_ entity: T.Type, predicate: NSPredicate? = nil) {
-        let objects = fetchAll(entity, predicate: predicate)
+    func deleteAll<T: NSManagedObject>(_ entity: T.Type, filteredBy predicate: NSPredicate? = nil) {
+        let objects = fetchAll(entity, filteredBy: predicate)
         
         for object in objects {
             delete(object)
         }
     }
     
-    func deleteAll<T: NSManagedObject>(_ entity: T.Type, predicateFormat: String, _ predicateArguments: CVarArg...) {
+    func deleteAll<T: NSManagedObject>(_ entity: T.Type, filteredBy predicateFormat: String, _ predicateArguments: CVarArg...) {
         var predicate: NSPredicate? = nil
         
         withVaList(predicateArguments) { arguments in
             predicate = NSPredicate(format: predicateFormat, arguments: arguments)
         }
         
-        deleteAll(entity, predicate: predicate)
+        deleteAll(entity, filteredBy: predicate)
     }
     
-    func fetch<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortDescriptors: [NSSortDescriptor]? = nil, predicate: NSPredicate? = nil) -> T? {
-        return fetchAll(entity, withRelationships: relationships, sortDescriptors: sortDescriptors, predicate: predicate).first
+    func fetch<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortedBy sortDescriptors: [NSSortDescriptor]? = nil, filteredBy predicate: NSPredicate? = nil) -> T? {
+        return fetchAll(entity, withRelationships: relationships, sortedBy: sortDescriptors, filteredBy: predicate).first
     }
     
-    func fetch<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortDescriptors: [NSSortDescriptor]? = nil, predicateFormat: String, _ predicateArguments: CVarArg...) -> T? {
+    func fetch<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortedBy sortDescriptors: [NSSortDescriptor]? = nil, filteredBy predicateFormat: String, _ predicateArguments: CVarArg...) -> T? {
         var predicate: NSPredicate? = nil
         
         withVaList(predicateArguments) { arguments in
             predicate = NSPredicate(format: predicateFormat, arguments: arguments)
         }
         
-        return fetch(entity, withRelationships: relationships, sortDescriptors: sortDescriptors, predicate: predicate)
+        return fetch(entity, withRelationships: relationships, sortedBy: sortDescriptors, filteredBy: predicate)
     }
     
-    func fetchAll<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortDescriptors: [NSSortDescriptor]? = nil, fetchLimit: Int = 0, predicate: NSPredicate? = nil) -> [T] {
+    func fetchAll<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, limit: Int = 0, sortedBy sortDescriptors: [NSSortDescriptor]? = nil, filteredBy predicate: NSPredicate? = nil) -> [T] {
         let fetchRequest = NSFetchRequest<T>(entityName: String(describing: T.self))
         fetchRequest.relationshipKeyPathsForPrefetching = relationships
         fetchRequest.sortDescriptors = sortDescriptors
-        fetchRequest.fetchLimit = fetchLimit
+        fetchRequest.fetchLimit = limit
         fetchRequest.predicate = predicate
         
         return (try? fetch(fetchRequest)) ?? [T]()
     }
     
-    func fetchAll<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, sortDescriptors: [NSSortDescriptor]? = nil, fetchLimit: Int = 0, predicateFormat: String, _ predicateArguments: CVarArg...) -> [T] {
+    func fetchAll<T: NSManagedObject>(_ entity: T.Type, withRelationships relationships: [String]? = nil, limit: Int = 0, sortedBy sortDescriptors: [NSSortDescriptor]? = nil, filteredBy predicateFormat: String, _ predicateArguments: CVarArg...) -> [T] {
         var predicate: NSPredicate? = nil
         
         withVaList(predicateArguments) { arguments in
             predicate = NSPredicate(format: predicateFormat, arguments: arguments)
         }
         
-        return fetchAll(entity, withRelationships: relationships, sortDescriptors: sortDescriptors, fetchLimit: fetchLimit, predicate: predicate)
+        return fetchAll(entity, withRelationships: relationships, limit: limit, sortedBy: sortDescriptors, filteredBy: predicate)
     }
     
-    func count<T: NSManagedObject>(_ entity: T.Type, predicate: NSPredicate? = nil) -> Int {
+    func count<T: NSManagedObject>(_ entity: T.Type, filteredBy predicate: NSPredicate? = nil) -> Int {
         let fetchRequest = NSFetchRequest<T>(entityName: String(describing: T.self))
         fetchRequest.predicate = predicate
         
         return (try? count(for: fetchRequest)) ?? 0
     }
     
-    func count<T: NSManagedObject>(_ entity: T.Type, predicateFormat: String, _ predicateArguments: CVarArg...) -> Int {
+    func count<T: NSManagedObject>(_ entity: T.Type, filteredBy predicateFormat: String, _ predicateArguments: CVarArg...) -> Int {
         var predicate: NSPredicate? = nil
         
         withVaList(predicateArguments) { arguments in
             predicate = NSPredicate(format: predicateFormat, arguments: arguments)
         }
         
-        return count(entity, predicate: predicate)
+        return count(entity, filteredBy: predicate)
     }
     
 }

--- a/Tests/Model/TestModel.xcdatamodeld/TestModel.xcdatamodel/contents
+++ b/Tests/Model/TestModel.xcdatamodeld/TestModel.xcdatamodel/contents
@@ -2,8 +2,9 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14492.1" systemVersion="18G87" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="TestEntity" representedClassName="TestEntity" syncable="YES" codeGenerationType="class">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="relatedEntity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TestEntity" inverseName="relatedEntity" inverseEntity="TestEntity" syncable="YES"/>
     </entity>
     <elements>
-        <element name="TestEntity" positionX="-63" positionY="-18" width="128" height="60"/>
+        <element name="TestEntity" positionX="-63" positionY="-18" width="128" height="75"/>
     </elements>
 </model>

--- a/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
+++ b/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
@@ -118,7 +118,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         mainContext.performAndWait {
             let predicate = NSPredicate(format: "%K = %@ OR %K = %@", #keyPath(TestEntity.name), "second", #keyPath(TestEntity.name), "fifth")
             
-            mainContext.deleteAll(TestEntity.self, predicate: predicate)
+            mainContext.deleteAll(TestEntity.self, filteredBy: predicate)
             
             let countRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
             let count = try! mainContext.count(for: countRequest)
@@ -131,7 +131,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            mainContext.deleteAll(TestEntity.self, predicateFormat: "%K = %@ OR %K = %@ OR %K = %@", #keyPath(TestEntity.name), "first", #keyPath(TestEntity.name), "second", #keyPath(TestEntity.name), "fifth")
+            mainContext.deleteAll(TestEntity.self, filteredBy: "%K = %@ OR %K = %@ OR %K = %@", #keyPath(TestEntity.name), "first", #keyPath(TestEntity.name), "second", #keyPath(TestEntity.name), "fifth")
             
             let countRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
             let count = try! mainContext.count(for: countRequest)
@@ -155,7 +155,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         mainContext.performAndWait {
             let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
-            let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor])
+            let entity = mainContext.fetch(TestEntity.self, sortedBy: [sortDescriptor])
             
             XCTAssertEqual(entity?.name, "third")
         }
@@ -166,7 +166,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         mainContext.performAndWait {
             let predicate = NSPredicate(format: "%K = %@", #keyPath(TestEntity.name), "second")
-            let entity = mainContext.fetch(TestEntity.self, predicate: predicate)
+            let entity = mainContext.fetch(TestEntity.self, filteredBy: predicate)
             
             XCTAssertEqual(entity?.name, "second")
         }
@@ -176,7 +176,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let entity = mainContext.fetch(TestEntity.self, predicateFormat: "%K = %@", #keyPath(TestEntity.name), "fifth")
+            let entity = mainContext.fetch(TestEntity.self, filteredBy: "%K = %@", #keyPath(TestEntity.name), "fifth")
             
             XCTAssertEqual(entity?.name, "fifth")
         }
@@ -188,7 +188,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         mainContext.performAndWait {
             let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
-            let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor], predicate: predicate)
+            let entity = mainContext.fetch(TestEntity.self, sortedBy: [sortDescriptor], filteredBy: predicate)
             
             XCTAssertEqual(entity?.name, "fourth")
         }
@@ -199,7 +199,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         mainContext.performAndWait {
             let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: true)
-            let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor], predicateFormat: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
+            let entity = mainContext.fetch(TestEntity.self, sortedBy: [sortDescriptor], filteredBy: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             
             XCTAssertEqual(entity?.name, "fifth")
         }
@@ -209,7 +209,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let entity = mainContext.fetch(TestEntity.self, withRelationships: [#keyPath(TestEntity.relatedEntity)], predicateFormat: "%K = %@", #keyPath(TestEntity.name), "second")
+            let entity = mainContext.fetch(TestEntity.self, withRelationships: [#keyPath(TestEntity.relatedEntity)], filteredBy: "%K = %@", #keyPath(TestEntity.name), "second")
             
             guard let relatedEntity = entity?.relatedEntity else {
                 XCTFail("Fetched entity should have a realted entity.")
@@ -235,7 +235,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         mainContext.performAndWait {
             let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: true)
-            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor])
+            let entities = mainContext.fetchAll(TestEntity.self, sortedBy: [sortDescriptor])
             
             XCTAssertEqual(entities.count, 5)
             
@@ -247,11 +247,11 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         }
     }
     
-    func testShouldFetchAllEntitiesUsingFetchLimit() {
+    func testShouldFetchAllEntitiesUsingLimit() {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let entities = mainContext.fetchAll(TestEntity.self, fetchLimit: 2)
+            let entities = mainContext.fetchAll(TestEntity.self, limit: 2)
             
             XCTAssertEqual(entities.count, 2)
         }
@@ -262,7 +262,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         mainContext.performAndWait {
             let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
-            let entities = mainContext.fetchAll(TestEntity.self, predicate: predicate)
+            let entities = mainContext.fetchAll(TestEntity.self, filteredBy: predicate)
             
             XCTAssertEqual(entities.count, 3)
         }
@@ -272,18 +272,18 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let entities = mainContext.fetchAll(TestEntity.self, predicateFormat: "%K ENDSWITH[c] %@", #keyPath(TestEntity.name), "h")
+            let entities = mainContext.fetchAll(TestEntity.self, filteredBy: "%K ENDSWITH[c] %@", #keyPath(TestEntity.name), "h")
             
             XCTAssertEqual(entities.count, 2)
         }
     }
     
-    func testShouldFetchAllEntitiesUsingSortDescriptorsAndFetchLimit() {
+    func testShouldFetchAllEntitiesUsingSortDescriptorsAndLimit() {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
             let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
-            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2)
+            let entities = mainContext.fetchAll(TestEntity.self, limit: 2, sortedBy: [sortDescriptor])
             
             XCTAssertEqual(entities.count, 2)
             
@@ -298,7 +298,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         mainContext.performAndWait {
             let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
             let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
-            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], predicate: predicate)
+            let entities = mainContext.fetchAll(TestEntity.self, sortedBy: [sortDescriptor], filteredBy: predicate)
             
             XCTAssertEqual(entities.count, 3)
             
@@ -313,7 +313,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         mainContext.performAndWait {
             let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: true)
-            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], predicateFormat: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
+            let entities = mainContext.fetchAll(TestEntity.self, sortedBy: [sortDescriptor], filteredBy: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             
             XCTAssertEqual(entities.count, 3)
             
@@ -323,12 +323,12 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         }
     }
     
-    func testShouldFetchAllEntitiesMatchingFetchLimitAndPredicate() {
+    func testShouldFetchAllEntitiesMatchingLimitAndPredicate() {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
             let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
-            let entities = mainContext.fetchAll(TestEntity.self, fetchLimit: 2, predicate: predicate)
+            let entities = mainContext.fetchAll(TestEntity.self, limit: 2, filteredBy: predicate)
             
             XCTAssertEqual(entities.count, 2)
             
@@ -344,11 +344,11 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         }
     }
     
-    func testShouldFetchAllEntitiesMatchingFetchLimitAndPredicateFormat() {
+    func testShouldFetchAllEntitiesMatchingLimitAndPredicateFormat() {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let entities = mainContext.fetchAll(TestEntity.self, fetchLimit: 2, predicateFormat: "%K CONTAINS[c] %@", #keyPath(TestEntity.name), "h")
+            let entities = mainContext.fetchAll(TestEntity.self, limit: 2, filteredBy: "%K CONTAINS[c] %@", #keyPath(TestEntity.name), "h")
             
             XCTAssertEqual(entities.count, 2)
             
@@ -364,13 +364,13 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         }
     }
     
-    func testShouldFetchAllEntitiesUsingSortDescriptorsFetchLimitAndPredicate() {
+    func testShouldFetchAllEntitiesUsingSortDescriptorsLimitAndPredicate() {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
             let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
             let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
-            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2, predicate: predicate)
+            let entities = mainContext.fetchAll(TestEntity.self, limit: 2, sortedBy: [sortDescriptor], filteredBy: predicate)
             
             XCTAssertEqual(entities.count, 2)
             
@@ -379,12 +379,12 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         }
     }
     
-    func testShouldFetchAllEntitiesUsingSortDescriptorsFetchLimitAndPredicateFormat() {
+    func testShouldFetchAllEntitiesUsingSortDescriptorsLimitAndPredicateFormat() {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
             let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
-            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2, predicateFormat: "%K CONTAINS[c] %@", #keyPath(TestEntity.name), "h")
+            let entities = mainContext.fetchAll(TestEntity.self, limit: 2, sortedBy: [sortDescriptor], filteredBy: "%K CONTAINS[c] %@", #keyPath(TestEntity.name), "h")
             
             XCTAssertEqual(entities.count, 2)
             
@@ -397,7 +397,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let entities = mainContext.fetchAll(TestEntity.self, withRelationships: [#keyPath(TestEntity.relatedEntity)], predicateFormat: "%K != NULL", #keyPath(TestEntity.relatedEntity))
+            let entities = mainContext.fetchAll(TestEntity.self, withRelationships: [#keyPath(TestEntity.relatedEntity)], filteredBy: "%K != NULL", #keyPath(TestEntity.relatedEntity))
             
             XCTAssertEqual(entities.count, 4)
             
@@ -432,7 +432,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         mainContext.performAndWait {
             let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
-            let count = mainContext.count(TestEntity.self, predicate: predicate)
+            let count = mainContext.count(TestEntity.self, filteredBy: predicate)
             
             XCTAssertEqual(count, 3)
         }
@@ -442,7 +442,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let count = mainContext.count(TestEntity.self, predicateFormat: "%K CONTAINS[c] %@", #keyPath(TestEntity.name), "o")
+            let count = mainContext.count(TestEntity.self, filteredBy: "%K CONTAINS[c] %@", #keyPath(TestEntity.name), "o")
             
             XCTAssertEqual(count, 2)
         }

--- a/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
+++ b/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
@@ -79,7 +79,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         mainContext.performAndWait {
             let fetchRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
-            fetchRequest.predicate = NSPredicate(format: "name = %@", "fourth")
+            fetchRequest.predicate = NSPredicate(format: "%K = %@", #keyPath(TestEntity.name), "fourth")
             fetchRequest.fetchLimit = 1
             
             let entity = try! mainContext.fetch(fetchRequest).first!
@@ -114,7 +114,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let predicate = NSPredicate(format: "name = %@ OR name = %@", "second", "fifth")
+            let predicate = NSPredicate(format: "%K = %@ OR %K = %@", #keyPath(TestEntity.name), "second", #keyPath(TestEntity.name), "fifth")
             
             mainContext.deleteAll(TestEntity.self, predicate: predicate)
             
@@ -129,7 +129,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            mainContext.deleteAll(TestEntity.self, predicateFormat: "name = %@ OR name = %@ OR name = %@", "first", "second", "fifth")
+            mainContext.deleteAll(TestEntity.self, predicateFormat: "%K = %@ OR %K = %@ OR %K = %@", #keyPath(TestEntity.name), "first", #keyPath(TestEntity.name), "second", #keyPath(TestEntity.name), "fifth")
             
             let countRequest = NSFetchRequest<TestEntity>(entityName: String(describing: TestEntity.self))
             let count = try! mainContext.count(for: countRequest)
@@ -152,7 +152,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
+            let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
             let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor])
             
             XCTAssertEqual(entity?.name, "third")
@@ -163,7 +163,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let predicate = NSPredicate(format: "name = %@", "second")
+            let predicate = NSPredicate(format: "%K = %@", #keyPath(TestEntity.name), "second")
             let entity = mainContext.fetch(TestEntity.self, predicate: predicate)
             
             XCTAssertEqual(entity?.name, "second")
@@ -174,7 +174,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let entity = mainContext.fetch(TestEntity.self, predicateFormat: "name = %@", "fifth")
+            let entity = mainContext.fetch(TestEntity.self, predicateFormat: "%K = %@", #keyPath(TestEntity.name), "fifth")
             
             XCTAssertEqual(entity?.name, "fifth")
         }
@@ -184,8 +184,8 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
-            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
+            let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
+            let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
             let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor], predicate: predicate)
             
             XCTAssertEqual(entity?.name, "fourth")
@@ -196,8 +196,8 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
-            let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor], predicateFormat: "name BEGINSWITH[c] %@", "f")
+            let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: true)
+            let entity = mainContext.fetch(TestEntity.self, sortDescriptors: [sortDescriptor], predicateFormat: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             
             XCTAssertEqual(entity?.name, "fifth")
         }
@@ -217,7 +217,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
+            let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: true)
             let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor])
             
             XCTAssertEqual(entities.count, 5)
@@ -244,7 +244,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             let entities = mainContext.fetchAll(TestEntity.self, predicate: predicate)
             
             XCTAssertEqual(entities.count, 3)
@@ -255,7 +255,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let entities = mainContext.fetchAll(TestEntity.self, predicateFormat: "name ENDSWITH[c] %@", "h")
+            let entities = mainContext.fetchAll(TestEntity.self, predicateFormat: "%K ENDSWITH[c] %@", #keyPath(TestEntity.name), "h")
             
             XCTAssertEqual(entities.count, 2)
         }
@@ -265,7 +265,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
+            let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
             let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2)
             
             XCTAssertEqual(entities.count, 2)
@@ -279,8 +279,8 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
-            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
+            let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], predicate: predicate)
             
             XCTAssertEqual(entities.count, 3)
@@ -295,8 +295,8 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let sortDescriptor = NSSortDescriptor(key: "name", ascending: true)
-            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], predicateFormat: "name BEGINSWITH[c] %@", "f")
+            let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: true)
+            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], predicateFormat: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             
             XCTAssertEqual(entities.count, 3)
             
@@ -310,7 +310,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             let entities = mainContext.fetchAll(TestEntity.self, fetchLimit: 2, predicate: predicate)
             
             XCTAssertEqual(entities.count, 2)
@@ -331,7 +331,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let entities = mainContext.fetchAll(TestEntity.self, fetchLimit: 2, predicateFormat: "name CONTAINS[c] %@", "h")
+            let entities = mainContext.fetchAll(TestEntity.self, fetchLimit: 2, predicateFormat: "%K CONTAINS[c] %@", #keyPath(TestEntity.name), "h")
             
             XCTAssertEqual(entities.count, 2)
             
@@ -351,8 +351,8 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
-            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
+            let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2, predicate: predicate)
             
             XCTAssertEqual(entities.count, 2)
@@ -366,8 +366,8 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let sortDescriptor = NSSortDescriptor(key: "name", ascending: false)
-            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2, predicateFormat: "name CONTAINS[c] %@", "h")
+            let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
+            let entities = mainContext.fetchAll(TestEntity.self, sortDescriptors: [sortDescriptor], fetchLimit: 2, predicateFormat: "%K CONTAINS[c] %@", #keyPath(TestEntity.name), "h")
             
             XCTAssertEqual(entities.count, 2)
             
@@ -390,7 +390,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let predicate = NSPredicate(format: "name BEGINSWITH[c] %@", "f")
+            let predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "f")
             let count = mainContext.count(TestEntity.self, predicate: predicate)
             
             XCTAssertEqual(count, 3)
@@ -401,7 +401,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         let mainContext = self.persistenceController.mainContext
         
         mainContext.performAndWait {
-            let count = mainContext.count(TestEntity.self, predicateFormat: "name CONTAINS[c] %@", "o")
+            let count = mainContext.count(TestEntity.self, predicateFormat: "%K CONTAINS[c] %@", #keyPath(TestEntity.name), "o")
             
             XCTAssertEqual(count, 2)
         }


### PR DESCRIPTION
### What?

#### New functionality:
- Ability fo fire faults of fetched entities.

#### Improvements:
- Compile time generated key paths for unit tests.
-  Change method signatures of NSManagedObjectContext helper methods in order to make them a bit more descriptive.

### Why?

Minimize the number of queries made to a persistent store when snapshotting model in Chatkit.

----

CC @pusher/sigsdk
