### PR TITLE
Persistence stack improvements

### DIFF
--- a/Pusher Platform iOS Example/Pusher Platform iOS Example.xcodeproj/project.pbxproj
+++ b/Pusher Platform iOS Example/Pusher Platform iOS Example.xcodeproj/project.pbxproj
@@ -130,7 +130,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1120;
 				ORGANIZATIONNAME = Pusher;
 				TargetAttributes = {
 					3302637C1DC2475E007D7317 = {
@@ -147,7 +147,7 @@
 			};
 			buildConfigurationList = 330263781DC2475D007D7317 /* Build configuration list for PBXProject "Pusher Platform iOS Example" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -212,6 +212,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -272,6 +273,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -154,19 +154,19 @@
 			isa = PBXGroup;
 			children = (
 				220E87CC22FAC9E4008B3B95 /* Context */,
-				222BAAE922F453250050B196 /* Controller */,
 				222BAAEC22F489010050B196 /* Error Handling */,
+				222BAAE922F453250050B196 /* Persistence Controller */,
 				22F0A47222F8599700787225 /* Store Description */,
 			);
 			name = Persistence;
 			sourceTree = "<group>";
 		};
-		222BAAE922F453250050B196 /* Controller */ = {
+		222BAAE922F453250050B196 /* Persistence Controller */ = {
 			isa = PBXGroup;
 			children = (
 				222BAAEA22F453310050B196 /* PersistenceController.swift */,
 			);
-			name = Controller;
+			name = "Persistence Controller";
 			sourceTree = "<group>";
 		};
 		222BAAEC22F489010050B196 /* Error Handling */ = {
@@ -366,25 +366,25 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1120;
 				TargetAttributes = {
 					33831C881A9CF61600B124F1 = {
 						CreatedOnToolsVersion = 6.3;
-						LastSwiftMigration = 1000;
+						LastSwiftMigration = 1120;
 					};
 					33831C931A9CF61600B124F1 = {
 						CreatedOnToolsVersion = 6.3;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1120;
 					};
 				};
 			};
 			buildConfigurationList = 33831C4D1A9CEDF800B124F1 /* Build configuration list for PBXProject "PusherPlatform" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
+				Base,
 			);
 			mainGroup = 33831C491A9CEDF800B124F1;
 			productRefGroup = 33831C8A1A9CF61600B124F1 /* Products */;
@@ -487,6 +487,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -531,6 +532,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/PusherPlatform.xcodeproj/project.pbxproj
+++ b/PusherPlatform.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		22029BAC22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22029BAB22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift */; };
+		220A34D12399433700520D06 /* ChangeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220A34D02399433700520D06 /* ChangeController.swift */; };
+		220A34D42399434F00520D06 /* FetchedResultsControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220A34D32399434F00520D06 /* FetchedResultsControllerWrapper.swift */; };
+		220A34D6239944D700520D06 /* ChangeControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220A34D5239944D700520D06 /* ChangeControllerTests.swift */; };
+		220A34DA2399582600520D06 /* TestChangeControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220A34D82399582300520D06 /* TestChangeControllerDelegate.swift */; };
 		220E87CE22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220E87CD22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift */; };
 		222BAAEB22F453310050B196 /* PersistenceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAEA22F453310050B196 /* PersistenceController.swift */; };
 		222BAAEE22F489180050B196 /* PersistenceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222BAAED22F489180050B196 /* PersistenceError.swift */; };
@@ -66,6 +70,10 @@
 
 /* Begin PBXFileReference section */
 		22029BAB22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSManagedObjectContext_PersistenceTests.swift; sourceTree = "<group>"; };
+		220A34D02399433700520D06 /* ChangeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeController.swift; sourceTree = "<group>"; };
+		220A34D32399434F00520D06 /* FetchedResultsControllerWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchedResultsControllerWrapper.swift; sourceTree = "<group>"; };
+		220A34D5239944D700520D06 /* ChangeControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeControllerTests.swift; sourceTree = "<group>"; };
+		220A34D82399582300520D06 /* TestChangeControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestChangeControllerDelegate.swift; sourceTree = "<group>"; };
 		220E87CD22FACA11008B3B95 /* NSManagedObjectContext+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Persistence.swift"; sourceTree = "<group>"; };
 		222BAAEA22F453310050B196 /* PersistenceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceController.swift; sourceTree = "<group>"; };
 		222BAAED22F489180050B196 /* PersistenceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceError.swift; sourceTree = "<group>"; };
@@ -134,6 +142,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		220A34CF2399432800520D06 /* Change Controller */ = {
+			isa = PBXGroup;
+			children = (
+				220A34D22399434900520D06 /* Wrapper */,
+				220A34D02399433700520D06 /* ChangeController.swift */,
+			);
+			name = "Change Controller";
+			sourceTree = "<group>";
+		};
+		220A34D22399434900520D06 /* Wrapper */ = {
+			isa = PBXGroup;
+			children = (
+				220A34D32399434F00520D06 /* FetchedResultsControllerWrapper.swift */,
+			);
+			name = Wrapper;
+			sourceTree = "<group>";
+		};
+		220A34D72399580700520D06 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				220A34D82399582300520D06 /* TestChangeControllerDelegate.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		220E87CC22FAC9E4008B3B95 /* Context */ = {
 			isa = PBXGroup;
 			children = (
@@ -153,6 +186,7 @@
 		222BAAE822F4531B0050B196 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				220A34CF2399432800520D06 /* Change Controller */,
 				220E87CC22FAC9E4008B3B95 /* Context */,
 				222BAAEC22F489010050B196 /* Error Handling */,
 				222BAAE922F453250050B196 /* Persistence Controller */,
@@ -198,6 +232,7 @@
 		22F0A47522F8629500787225 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				220A34D5239944D700520D06 /* ChangeControllerTests.swift */,
 				22029BAB22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift */,
 				22F0A47A22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift */,
 				22F0A47622F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift */,
@@ -292,11 +327,12 @@
 		33BB995C1D21225B00B25C2A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				220A34D72399580700520D06 /* Helpers */,
 				220E87CF22FAF62B008B3B95 /* Model */,
 				22F0A47522F8629500787225 /* Persistence */,
+				33BB99671D21226C00B25C2A /* Info.plist */,
 				33C2FB141F3E99C4006AB501 /* MessageParserTests.swift */,
 				3301FDDC2047028D00AE591A /* SDKInfoHeaderTests.swift */,
-				33BB99671D21226C00B25C2A /* Info.plist */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -439,12 +475,14 @@
 				33025C07212B346800C12249 /* PPRepeater.swift in Sources */,
 				22528E8722F994CE00F25C1C /* DispatchSemaphore.swift in Sources */,
 				332E05E61DDCA3DB007A55FB /* PPMessageParser.swift in Sources */,
+				220A34D42399434F00520D06 /* FetchedResultsControllerWrapper.swift in Sources */,
 				22F0A46F22F8224600787225 /* PersistentStoreDescription+RLBErrorRecovery.swift in Sources */,
 				3337CF652035E9FD000892B6 /* PPSDKInfo.swift in Sources */,
 				336F2A3B1FFBF17E0098687B /* PPSubscriptionURLSessionDelegate.swift in Sources */,
 				22F0A47422F85AB700787225 /* NSPersistentStoreDescription+StoreTypes.swift in Sources */,
 				334ED1F01FE96CE20041A9CA /* PPDownloadDelegate.swift in Sources */,
 				A1C545371F753E3700F15509 /* PPHTTPBodyPair.swift in Sources */,
+				220A34D12399433700520D06 /* ChangeController.swift in Sources */,
 				332E05E81DDCA919007A55FB /* PPMessage.swift in Sources */,
 				338202501FFCFF3B00DC9664 /* PPUploadURLSessionDelegate.swift in Sources */,
 				33935EAC1DA539BD00C5C064 /* PPHTTPEndpointTokenProvider.swift in Sources */,
@@ -465,7 +503,9 @@
 				33C2FB151F3E99C4006AB501 /* MessageParserTests.swift in Sources */,
 				22029BAC22FB1FDE00E9EC23 /* NSManagedObjectContext_PersistenceTests.swift in Sources */,
 				22F0A47722F862AB00787225 /* NSPersistentStoreDescription_StoreTypesTests.swift in Sources */,
+				220A34D6239944D700520D06 /* ChangeControllerTests.swift in Sources */,
 				22F0A47D22F879AA00787225 /* PersistenceControllerTests.swift in Sources */,
+				220A34DA2399582600520D06 /* TestChangeControllerDelegate.swift in Sources */,
 				2296D72422F9DC1D00921EDA /* TestModel.xcdatamodeld in Sources */,
 				3301FDDE2047035500AE591A /* SDKInfoHeaderTests.swift in Sources */,
 				22F0A47B22F870F100787225 /* NSPersistentStoreDescription_RecoveryTests.swift in Sources */,

--- a/PusherPlatform.xcodeproj/xcshareddata/xcschemes/PusherPlatform.xcscheme
+++ b/PusherPlatform.xcodeproj/xcshareddata/xcschemes/PusherPlatform.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1120"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -40,9 +40,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       enableThreadSanitizer = "YES"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "33831C881A9CF61600B124F1"
+            BuildableName = "PusherPlatform.framework"
+            BlueprintName = "PusherPlatform"
+            ReferencedContainer = "container:PusherPlatform.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -55,17 +64,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "33831C881A9CF61600B124F1"
-            BuildableName = "PusherPlatform.framework"
-            BlueprintName = "PusherPlatform"
-            ReferencedContainer = "container:PusherPlatform.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,6 +75,7 @@
       debugDocumentVersioning = "YES"
       stopOnEveryThreadSanitizerIssue = "YES"
       stopOnEveryMainThreadCheckerIssue = "YES"
+      migratedStopOnEveryIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
@@ -88,8 +87,6 @@
             ReferencedContainer = "container:PusherPlatform.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/ChangeController.swift
+++ b/Sources/ChangeController.swift
@@ -1,0 +1,162 @@
+import Foundation
+import CoreData
+
+public class ChangeController<ResultType> where ResultType: NSManagedObject {
+    
+    // MARK: - Properties
+    
+    public let sortDescriptors: [NSSortDescriptor]
+    public let logger: PPLogger?
+    
+    weak var delegate: ChangeControllerDelegate?
+    
+    private let wrapper: FetchedResultsControllerWrapper<ResultType>
+    private var insertions: IndexSet
+    
+    // MARK: - Accessors
+    
+    public var context: NSManagedObjectContext {
+        return wrapper.fetchedResultsController.managedObjectContext
+    }
+    
+    public var entityName: String {
+        return wrapper.fetchedResultsController.fetchRequest.entityName ?? String(describing: ResultType.self)
+    }
+    
+    public var predicate: NSPredicate? {
+        return wrapper.fetchedResultsController.fetchRequest.predicate
+    }
+    
+    public var fetchBatchSize: Int {
+        return wrapper.fetchedResultsController.fetchRequest.fetchBatchSize
+    }
+    
+    public var numberOfObjects: Int {
+        return wrapper.fetchedResultsController.fetchedObjects?.count ?? 0
+    }
+    
+    public var objects: [ResultType] {
+        return wrapper.fetchedResultsController.fetchedObjects ?? []
+    }
+    
+    // MARK: - Initializers
+    
+    public init(entityName: String, sortDescriptors: [NSSortDescriptor], predicate: NSPredicate? = nil, fetchBatchSize: Int = 50, context: NSManagedObjectContext, logger: PPLogger? = nil) {
+        self.logger = logger
+        self.sortDescriptors = sortDescriptors
+        self.insertions = IndexSet()
+        
+        let fetchRequest = NSFetchRequest<ResultType>(entityName: entityName)
+        fetchRequest.fetchBatchSize = fetchBatchSize
+        fetchRequest.sortDescriptors = sortDescriptors
+        fetchRequest.predicate = predicate
+        
+        let fetchedResultsController = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: context, sectionNameKeyPath: nil, cacheName: nil)
+        
+        self.wrapper = FetchedResultsControllerWrapper(fetchedResultsController: fetchedResultsController)
+        self.wrapper.delegate = self
+        
+        self.performFetch()
+    }
+    
+    public convenience init(sortDescriptors: [NSSortDescriptor], predicate: NSPredicate? = nil, fetchBatchSize: Int = 50, context: NSManagedObjectContext, logger: PPLogger? = nil) {
+        let entityName = String(describing: ResultType.self)
+        self.init(entityName: entityName, sortDescriptors: sortDescriptors, predicate: predicate, fetchBatchSize: fetchBatchSize, context: context, logger: logger)
+    }
+    
+    // MARK: - Public methods
+    
+    public func object(at index: Int) -> ResultType? {
+        guard index < numberOfObjects else {
+            return nil
+        }
+        
+        let indexPath = IndexPath(item: index, section: 0)
+        return wrapper.fetchedResultsController.object(at: indexPath)
+    }
+    
+    public func index(for object: ResultType) -> Int? {
+        let indexPath = wrapper.fetchedResultsController.indexPath(forObject: object)
+        return indexPath?.item
+    }
+    
+    // MARK: - Private methods
+    
+    private func performFetch() {
+        do {
+            try wrapper.fetchedResultsController.performFetch()
+        } catch {
+            logger?.log("Failed to perform fetch using the provided parameters.", logLevel: .warning)
+        }
+    }
+    
+    private func commitInsertions() {
+        guard !insertions.isEmpty else {
+            return
+        }
+        
+        let insertedObjects = insertions.map { objects[$0] }
+        
+        delegate?.changeController(self, didInsertObjects: insertedObjects, at: insertions)
+        
+        insertions.removeAll()
+    }
+    
+}
+
+// MARK: - Wrapper delegate
+
+extension ChangeController: FetchedResultsControllerWrapperDelegate {
+    
+    func fetchedResultsControllerWrapper<T>(_ fetchedResultsControllerWrapper: FetchedResultsControllerWrapper<T>, didChange object: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) where T : NSManagedObject {
+        guard let object = object as? ResultType else {
+            return
+        }
+        
+        switch type {
+        case .insert:
+            guard let index = newIndexPath?.item else {
+                return
+            }
+            
+            insertions.insert(index)
+        
+        case .update:
+            guard let index = indexPath?.item else {
+                return
+            }
+            
+            delegate?.changeController(self, didUpdateObject: object, at: index)
+            
+        case .move:
+            guard let oldIndex = indexPath?.item, let newIndex = newIndexPath?.item else {
+                return
+            }
+            
+            delegate?.changeController(self, didMoveObject: object, from: oldIndex, to: newIndex)
+        
+        case .delete:
+            guard let index = indexPath?.item else {
+                return
+            }
+            
+            delegate?.changeController(self, didDeleteObject: object, at: index)
+        }
+    }
+    
+    func fetchedResultsControllerWrapperDidChangeContent<T>(_ fetchedResultsControllerWrapper: FetchedResultsControllerWrapper<T>) where T : NSManagedObject {
+        commitInsertions()
+    }
+    
+}
+
+// MARK: - Delegate
+
+public protocol ChangeControllerDelegate: class {
+    
+    func changeController<ResultType: NSManagedObject>(_ changeController: ChangeController<ResultType>, didInsertObjects objects: [ResultType], at indexes: IndexSet)
+    func changeController<ResultType: NSManagedObject>(_ changeController: ChangeController<ResultType>, didUpdateObject object: ResultType, at index: Int)
+    func changeController<ResultType: NSManagedObject>(_ changeController: ChangeController<ResultType>, didMoveObject object: ResultType, from oldIndex: Int, to newIndex: Int)
+    func changeController<ResultType: NSManagedObject>(_ changeController: ChangeController<ResultType>, didDeleteObject object: ResultType, at index: Int)
+    
+}

--- a/Sources/FetchedResultsControllerWrapper.swift
+++ b/Sources/FetchedResultsControllerWrapper.swift
@@ -1,0 +1,41 @@
+import Foundation
+import CoreData
+
+class FetchedResultsControllerWrapper<ResultType>: NSObject, NSFetchedResultsControllerDelegate where ResultType: NSManagedObject {
+    
+    // MARK: - Properties
+    
+    let fetchedResultsController: NSFetchedResultsController<ResultType>
+    
+    weak var delegate: FetchedResultsControllerWrapperDelegate?
+    
+    // MARK: - Initializers
+    
+    init(fetchedResultsController: NSFetchedResultsController<ResultType>) {
+        self.fetchedResultsController = fetchedResultsController
+        
+        super.init()
+        
+        self.fetchedResultsController.delegate = self
+    }
+    
+    // MARK: - NSFetchedResultsControllerDelegate
+    
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+        delegate?.fetchedResultsControllerWrapper(self, didChange: anObject, at: indexPath, for: type, newIndexPath: newIndexPath)
+    }
+    
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        delegate?.fetchedResultsControllerWrapperDidChangeContent(self)
+    }
+    
+}
+
+// MARK: - Delegate
+
+protocol FetchedResultsControllerWrapperDelegate: class {
+    
+    func fetchedResultsControllerWrapper<ResultType: NSManagedObject>(_ fetchedResultsControllerWrapper: FetchedResultsControllerWrapper<ResultType>, didChange object: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?)
+    func fetchedResultsControllerWrapperDidChangeContent<ResultType: NSManagedObject>(_ fetchedResultsControllerWrapper: FetchedResultsControllerWrapper<ResultType>)
+    
+}

--- a/Sources/NSManagedObjectContext+Persistence.swift
+++ b/Sources/NSManagedObjectContext+Persistence.swift
@@ -84,4 +84,31 @@ public extension NSManagedObjectContext {
         return count(entity, filteredBy: predicate)
     }
     
+    // MARK: - Internal methods
+    
+    internal func save(shouldWait: Bool, completionHandler: @escaping (Error?) -> Void) {
+        let saveTask = { [weak self] in
+            guard let self = self else { return }
+            
+            guard self.hasChanges else {
+                completionHandler(nil)
+                return
+            }
+            
+            do {
+                try self.save()
+                completionHandler(nil)
+            } catch {
+                completionHandler(error)
+            }
+        }
+        
+        if shouldWait {
+            performAndWait(saveTask)
+        }
+        else {
+            perform(saveTask)
+        }
+    }
+    
 }

--- a/Tests/Helpers/TestChangeControllerDelegate.swift
+++ b/Tests/Helpers/TestChangeControllerDelegate.swift
@@ -1,0 +1,64 @@
+import Foundation
+import CoreData
+@testable import PusherPlatform
+
+class TestChangeControllerDelegate<T>: ChangeControllerDelegate where T: NSManagedObject {
+    
+    // MARK: - Types
+    
+    typealias InsertCallback = ([T], IndexSet) -> Void
+    typealias UpdateCallback = (T, Int) -> Void
+    typealias MoveCallback = (T, Int, Int) -> Void
+    typealias DeleteCallback = (T, Int) -> Void
+    
+    // MARK: - Properties
+    
+    let insertCallback: InsertCallback?
+    let updateCallback: UpdateCallback?
+    let moveCallback: MoveCallback?
+    let deleteCallback: DeleteCallback?
+    
+    // MARK: - Initializers
+    
+    init(insertCallback: InsertCallback? = nil, updateCallback: UpdateCallback? = nil, moveCallback: MoveCallback? = nil, deleteCallback: DeleteCallback? = nil) {
+        self.insertCallback = insertCallback
+        self.updateCallback = updateCallback
+        self.moveCallback = moveCallback
+        self.deleteCallback = deleteCallback
+    }
+    
+    // MARK: - ChangeControllerDelegate
+    
+    func changeController<ResultType>(_ changeController: ChangeController<ResultType>, didInsertObjects objects: [ResultType], at indexes: IndexSet) where ResultType : NSManagedObject {
+        guard let insertCallback = self.insertCallback, let objects = objects as? [T] else {
+            return
+        }
+        
+        insertCallback(objects, indexes)
+    }
+    
+    func changeController<ResultType>(_ changeController: ChangeController<ResultType>, didUpdateObject object: ResultType, at index: Int) where ResultType : NSManagedObject {
+        guard let updateCallback = self.updateCallback, let object = object as? T else {
+            return
+        }
+        
+        updateCallback(object, index)
+    }
+    
+    func changeController<ResultType>(_ changeController: ChangeController<ResultType>, didMoveObject object: ResultType, from oldIndex: Int, to newIndex: Int) where ResultType : NSManagedObject {
+        guard let moveCallback = self.moveCallback, let object = object as? T else {
+            return
+        }
+        
+        moveCallback(object, oldIndex, newIndex)
+    }
+    
+    func changeController<ResultType>(_ changeController: ChangeController<ResultType>, didDeleteObject object: ResultType, at index: Int) where ResultType : NSManagedObject {
+        guard let deleteCallback = self.deleteCallback, let object = object as? T else {
+            return
+        }
+        
+        deleteCallback(object, index)
+    }
+    
+}

--- a/Tests/Persistence/ChangeControllerTests.swift
+++ b/Tests/Persistence/ChangeControllerTests.swift
@@ -1,0 +1,441 @@
+import XCTest
+import CoreData
+@testable import PusherPlatform
+
+class ChangeControllerTests: XCTestCase {
+    
+    // MARK: - Properties
+    
+    var persistenceController: PersistenceController!
+    var changeController: ChangeController<TestEntity>!
+    
+    var sortDescriptors: [NSSortDescriptor]!
+    var predicate: NSPredicate!
+    var logger: PPLogger!
+    
+    // MARK: - Tests lifecycle
+    
+    override func setUp() {
+        super.setUp()
+        
+        guard let url = Bundle(for: type(of: self)).url(forResource: "TestModel", withExtension: "momd"), let model = NSManagedObjectModel(contentsOf: url) else {
+            fatalError("Unable to locate test model.")
+        }
+        
+        let storeDescription = NSPersistentStoreDescription(inMemoryPersistentStoreDescription: ())
+        
+        self.logger = PPDefaultLogger()
+        
+        let instantiationExpectation = self.expectation(description: "Instantiation")
+        
+        do {
+            self.persistenceController = try PersistenceController(model: model, storeDescriptions: [storeDescription], logger: self.logger) { error in
+                guard error == nil else {
+                    fatalError("Failed to create in-memory store.")
+                }
+                
+                instantiationExpectation.fulfill()
+            }
+        } catch {
+            fatalError("Failed to instantiat persistence controller.")
+        }
+        
+        waitForExpectations(timeout: 5.0)
+        
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            let firstEntity = context.create(TestEntity.self)
+            firstEntity.name = "Aaron"
+            
+            let secondEntity = context.create(TestEntity.self)
+            secondEntity.name = "Alexa"
+            
+            let thirdEntity = context.create(TestEntity.self)
+            thirdEntity.name = "Aurelia"
+            
+            let fourthEntity = context.create(TestEntity.self)
+            fourthEntity.name = "Bob"
+            
+            self.persistenceController.save()
+        }
+        
+        let sortDescriptor = NSSortDescriptor(key: #keyPath(TestEntity.name), ascending: false)
+        self.sortDescriptors = [sortDescriptor]
+        
+        self.predicate = NSPredicate(format: "%K BEGINSWITH[c] %@", #keyPath(TestEntity.name), "A")
+        
+        self.changeController = ChangeController(sortDescriptors: self.sortDescriptors,
+                                                 predicate: self.predicate,
+                                                 fetchBatchSize: 10,
+                                                 context: self.persistenceController.mainContext,
+                                                 logger: self.logger)
+    }
+    
+    // MARK: - Tests
+    
+    func testShouldHaveCorrectSortDescriptors() {
+        XCTAssertEqual(self.changeController.sortDescriptors, self.sortDescriptors)
+    }
+    
+    func testShouldHaveCorrectPredicate() {
+        XCTAssertEqual(self.changeController.predicate, self.predicate)
+    }
+    
+    func testShouldNotHavePredicateByDefault() {
+        let changeController = ChangeController<TestEntity>(sortDescriptors: self.sortDescriptors,
+                                                            fetchBatchSize: 10,
+                                                            context: self.persistenceController.mainContext,
+                                                            logger: self.logger)
+        
+        XCTAssertNil(changeController.predicate)
+    }
+    
+    func testShouldHaveCorrectFetchBatchSize() {
+        XCTAssertEqual(self.changeController.fetchBatchSize, 10)
+    }
+    
+    func testShouldHaveCorrectDefaultFetchBatchSize() {
+        let changeController = ChangeController<TestEntity>(sortDescriptors: self.sortDescriptors,
+                                                            predicate: self.predicate,
+                                                            context: self.persistenceController.mainContext,
+                                                            logger: self.logger)
+        
+        XCTAssertEqual(changeController.fetchBatchSize, 50)
+    }
+    
+    func testShouldHaveLogger() {
+        XCTAssertNotNil(self.changeController.logger)
+    }
+    
+    func testShouldNotHaveLoggerByDefault() {
+        let changeController = ChangeController<TestEntity>(sortDescriptors: self.sortDescriptors,
+                                                            predicate: self.predicate,
+                                                            fetchBatchSize: 10,
+                                                            context: self.persistenceController.mainContext)
+        
+        XCTAssertNil(changeController.logger)
+    }
+    
+    func testShouldHaveCorrectContext() {
+        XCTAssertEqual(self.changeController.context, self.persistenceController.mainContext)
+    }
+    
+    func testShouldHaveCorrectEntityName() {
+        let changeController = ChangeController<TestEntity>(entityName: "TestEntity",
+                                                            sortDescriptors: self.sortDescriptors,
+                                                            predicate: self.predicate,
+                                                            fetchBatchSize: 10,
+                                                            context: self.persistenceController.mainContext,
+                                                            logger: self.logger)
+        
+        XCTAssertEqual(changeController.entityName, String(describing: TestEntity.self))
+    }
+    
+    func testShouldHaveCorrectDefaultEntityName() {
+        XCTAssertEqual(self.changeController.entityName, String(describing: TestEntity.self))
+    }
+    
+    func testShouldSetDelegate() {
+        let delegate = TestChangeControllerDelegate<TestEntity>()
+        self.changeController.delegate = delegate
+        
+        XCTAssertNotNil(self.changeController.delegate)
+    }
+    
+    func testShouldNotHaveDelegateByDefault() {
+        XCTAssertNil(self.changeController.delegate)
+    }
+    
+    func testShouldHaveCorrectNumberOfObjects() {
+        XCTAssertEqual(self.changeController.numberOfObjects, 3)
+    }
+    
+    func testShouldHaveCorrectObjectsOrderedUsingSortDescriptors() {
+        XCTAssertEqual(self.changeController.objects.count, 3)
+        XCTAssertEqual(self.changeController.objects[0].name, "Aurelia")
+        XCTAssertEqual(self.changeController.objects[1].name, "Alexa")
+        XCTAssertEqual(self.changeController.objects[2].name, "Aaron")
+    }
+    
+    func testShouldReturnCorrectObjectAtProvidedIndex() {
+        XCTAssertEqual(self.changeController.object(at: 2)?.name, "Aaron")
+    }
+    
+    func testShouldNotReturnObjectForOutOfBoundsIndex() {
+        XCTAssertNil(self.changeController.object(at: 3))
+    }
+    
+    func testShouldReturnCorrectIndexForProvidedObject() {
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            guard let object = context.fetch(TestEntity.self, filteredBy: "%K == %@", #keyPath(TestEntity.name), "Alexa") else {
+                XCTFail("Context should contain test entity.")
+                return
+            }
+            
+            XCTAssertEqual(self.changeController.index(for: object), 1)
+        }
+    }
+    
+    func testShouldNotReturnIndexForNotManagedObject() {
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            guard let object = context.fetch(TestEntity.self, filteredBy: "%K == %@", #keyPath(TestEntity.name), "Bob") else {
+                XCTFail("Context should contain test entity.")
+                return
+            }
+            
+            XCTAssertNil(self.changeController.index(for: object))
+        }
+    }
+    
+    func testShouldNotifyAboutInsertedObjectsIncludedByPredicate() {
+        let expectation = self.expectation(description: "Delegate Notification")
+        
+        let delegate = TestChangeControllerDelegate<TestEntity>(insertCallback: { objects, indexes in
+            XCTAssertEqual(objects.count, 2)
+            XCTAssertEqual(objects.first?.name, "Ash")
+            XCTAssertEqual(objects.last?.name, "Abby")
+            
+            XCTAssertEqual(indexes.count, 2)
+            XCTAssertEqual(indexes.first, 1)
+            XCTAssertEqual(indexes.last, 3)
+            
+            expectation.fulfill()
+        })
+        self.changeController.delegate = delegate
+        
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            let firstEntity = context.create(TestEntity.self)
+            firstEntity.name = "Abby"
+            
+            let secondEntity = context.create(TestEntity.self)
+            secondEntity.name = "Ash"
+            
+            self.persistenceController.save()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testShouldNotNotifyAboutInsertedObjectsNotIncludedByPredicate() {
+        let expectation = self.expectation(description: "Delegate Notification")
+        
+        let delegate = TestChangeControllerDelegate<TestEntity>(insertCallback: { _, _ in
+            XCTFail("Delegate method should not be called.")
+        })
+        self.changeController.delegate = delegate
+        
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            let entity = context.create(TestEntity.self)
+            entity.name = "George"
+            
+            self.persistenceController.save() { _ in
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testShouldNotifyAboutUpdatedObject() {
+        let expectation = self.expectation(description: "Delegate Notification")
+        
+        let delegate = TestChangeControllerDelegate<TestEntity>(updateCallback: { object, index in
+            XCTAssertEqual(object.name, "Abby")
+            XCTAssertEqual(index, 2)
+            
+            guard let originalValue = object.changedValuesForCurrentEvent()[#keyPath(TestEntity.name)] as? String else {
+                XCTFail("Object should contain original value.")
+                return
+            }
+            
+            XCTAssertEqual(originalValue, "Aaron")
+            
+            expectation.fulfill()
+        })
+        self.changeController.delegate = delegate
+        
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            guard let entity = context.fetch(TestEntity.self, filteredBy: "%K == %@", #keyPath(TestEntity.name), "Aaron") else {
+                XCTFail("Context should contain test entity.")
+                return
+            }
+            
+            entity.name = "Abby"
+            
+            self.persistenceController.save()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testShouldNotifyAboutInsertedObjectWhenUpdatingObjectInitialyNotIncludedByPredicate() {
+        let expectation = self.expectation(description: "Delegate Notification")
+        
+        let delegate = TestChangeControllerDelegate<TestEntity>(insertCallback: { objects, indexes in
+            XCTAssertEqual(objects.count, 1)
+            XCTAssertEqual(objects.first?.name, "Abby")
+            
+            XCTAssertEqual(indexes.count, 1)
+            XCTAssertEqual(indexes.first, 2)
+            
+            guard let originalValue = objects.first?.changedValuesForCurrentEvent()[#keyPath(TestEntity.name)] as? String else {
+                XCTFail("Object should contain original value.")
+                return
+            }
+            
+            XCTAssertEqual(originalValue, "Bob")
+            
+            expectation.fulfill()
+        })
+        self.changeController.delegate = delegate
+        
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            guard let entity = context.fetch(TestEntity.self, filteredBy: "%K == %@", #keyPath(TestEntity.name), "Bob") else {
+                XCTFail("Context should contain test entity.")
+                return
+            }
+            
+            entity.name = "Abby"
+            
+            self.persistenceController.save()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testShouldNotifyAboutDeletedObjectWhenUpdatingObjectInitialyIncludedByPredicate() {
+        let expectation = self.expectation(description: "Delegate Notification")
+        
+        let delegate = TestChangeControllerDelegate<TestEntity>(deleteCallback: { object, index in
+            XCTAssertEqual(object.name, "George")
+            XCTAssertEqual(index, 1)
+            
+            guard let originalValue = object.changedValuesForCurrentEvent()[#keyPath(TestEntity.name)] as? String else {
+                XCTFail("Object should contain original value.")
+                return
+            }
+            
+            XCTAssertEqual(originalValue, "Alexa")
+            
+            expectation.fulfill()
+        })
+        self.changeController.delegate = delegate
+        
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            guard let entity = context.fetch(TestEntity.self, filteredBy: "%K == %@", #keyPath(TestEntity.name), "Alexa") else {
+                XCTFail("Context should contain test entity.")
+                return
+            }
+            
+            entity.name = "George"
+            
+            self.persistenceController.save()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testShouldNotifyAboutMovedObject() {
+        let expectation = self.expectation(description: "Delegate Notification")
+        
+        let delegate = TestChangeControllerDelegate<TestEntity>(moveCallback: { object, oldIndex, newIndex in
+            XCTAssertEqual(object.name, "Abby")
+            XCTAssertEqual(oldIndex, 0)
+            XCTAssertEqual(newIndex, 1)
+            
+            guard let originalValue = object.changedValuesForCurrentEvent()[#keyPath(TestEntity.name)] as? String else {
+                XCTFail("Object should contain original value.")
+                return
+            }
+            
+            XCTAssertEqual(originalValue, "Aurelia")
+            
+            expectation.fulfill()
+        })
+        self.changeController.delegate = delegate
+        
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            guard let entity = context.fetch(TestEntity.self, filteredBy: "%K == %@", #keyPath(TestEntity.name), "Aurelia") else {
+                XCTFail("Context should contain test entity.")
+                return
+            }
+            
+            entity.name = "Abby"
+            
+            self.persistenceController.save()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testShouldNotifyAboutDeletedObjectWhenObjectInitialyIncludedByPredicate() {
+        let expectation = self.expectation(description: "Delegate Notification")
+        
+        let delegate = TestChangeControllerDelegate<TestEntity>(deleteCallback: { object, index in
+            XCTAssertEqual(object.name, "Aurelia")
+            XCTAssertEqual(index, 0)
+            
+            expectation.fulfill()
+        })
+        self.changeController.delegate = delegate
+        
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            guard let entity = context.fetch(TestEntity.self, filteredBy: "%K == %@", #keyPath(TestEntity.name), "Aurelia") else {
+                XCTFail("Context should contain test entity.")
+                return
+            }
+            
+            context.delete(entity)
+            
+            self.persistenceController.save()
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testShouldNotNotifyAboutDeletedObjectWhenObjectNotInitialyIncludedByPredicate() {
+        let expectation = self.expectation(description: "Delegate Notification")
+        
+        let delegate = TestChangeControllerDelegate<TestEntity>(deleteCallback: { _, _ in
+            XCTFail("Delegate method should not be called.")
+        })
+        self.changeController.delegate = delegate
+        
+        let context = self.persistenceController.mainContext
+        
+        context.performAndWait {
+            guard let entity = context.fetch(TestEntity.self, filteredBy: "%K == %@", #keyPath(TestEntity.name), "Bob") else {
+                XCTFail("Context should contain test entity.")
+                return
+            }
+            
+            context.delete(entity)
+            
+            self.persistenceController.save() { _ in
+                expectation.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+}

--- a/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
+++ b/Tests/Persistence/NSManagedObjectContext_PersistenceTests.swift
@@ -14,8 +14,7 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         super.setUp()
         
         guard let url = Bundle(for: type(of: self)).url(forResource: "TestModel", withExtension: "momd"), let model = NSManagedObjectModel(contentsOf: url) else {
-            assertionFailure("Unable to locate test model.")
-            return
+            fatalError("Unable to locate test model.")
         }
         
         let storeDescription = NSPersistentStoreDescription(inMemoryPersistentStoreDescription: ())
@@ -24,15 +23,14 @@ class NSManagedObjectContext_PersistenceTests: XCTestCase {
         
         do {
             self.persistenceController = try PersistenceController(model: model, storeDescriptions: [storeDescription]) { error in
-                if error != nil {
-                    assertionFailure("Failed to create in-memory store.")
+                guard error == nil else {
+                    fatalError("Failed to create in-memory store.")
                 }
                 
                 instantiationExpectation.fulfill()
             }
         } catch {
-            assertionFailure("Failed to instantiat persistence controller.")
-            instantiationExpectation.fulfill()
+            fatalError("Failed to instantiat persistence controller.")
         }
         
         waitForExpectations(timeout: 5.0)

--- a/Tests/Persistence/PersistenceControllerTests.swift
+++ b/Tests/Persistence/PersistenceControllerTests.swift
@@ -2,8 +2,6 @@ import XCTest
 import CoreData
 @testable import PusherPlatform
 
-import XCTest
-
 class PersistenceControllerTests: XCTestCase {
     
     // MARK: - Properties
@@ -18,8 +16,7 @@ class PersistenceControllerTests: XCTestCase {
         super.setUp()
         
         guard let url = Bundle(for: type(of: self)).url(forResource: "TestModel", withExtension: "momd"), let model = NSManagedObjectModel(contentsOf: url) else {
-            assertionFailure("Unable to locate test model.")
-            return
+            fatalError("Unable to locate test model.")
         }
         
         self.testModel = model
@@ -28,15 +25,14 @@ class PersistenceControllerTests: XCTestCase {
         
         do {
             self.persistenceController = try PersistenceController(model: self.testModel, storeDescriptions: [self.testStoreDescription], logger: PPDefaultLogger()) { error in
-                if error != nil {
-                    assertionFailure("Failed to create in-memory store.")
+                guard error == nil else {
+                    fatalError("Failed to create in-memory store.")
                 }
                 
                 instantiationExpectation.fulfill()
             }
         } catch {
-            assertionFailure("Failed to instantiat persistence controller.")
-            instantiationExpectation.fulfill()
+            fatalError("Failed to instantiat persistence controller.")
         }
         
         waitForExpectations(timeout: 5.0)


### PR DESCRIPTION
### What?

- Private context no longer parent of background task contexts.
- `ChangeController` - A wrapper for `NSFetchedResultsController` structured in a way that better suits our needs.
- Project settings updated for Xcode 11

### Why?

Chatkit SDK 2.0

----

CC @pusher/sigsdk
