### PR TITLE
OKP Auth bug fix

### DIFF
--- a/Platform/Authentication/Token/OAuthToken.swift
+++ b/Platform/Authentication/Token/OAuthToken.swift
@@ -4,7 +4,7 @@ struct OAuthToken: Token {
     
     // MARK: - Properties
     
-    let token: String
+    let value: String
     let expiryDate: Date
     
 }
@@ -15,7 +15,7 @@ extension OAuthToken: Decodable {
     
     enum CodingKeys: String, CodingKey {
         
-        case token = "access_token"
+        case value = "access_token"
         case expiryDate = "expires_in"
         
     }
@@ -25,7 +25,7 @@ extension OAuthToken: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
-        self.token = try container.decode(String.self, forKey: .token)
+        self.value = try container.decode(String.self, forKey: .value)
         self.expiryDate = Date(timeIntervalSinceNow: try container.decode(TimeInterval.self, forKey: .expiryDate))
     }
     

--- a/Platform/Authentication/Token/Token.swift
+++ b/Platform/Authentication/Token/Token.swift
@@ -6,7 +6,7 @@ public protocol Token {
     // MARK: - Properties
     
     /// String representation of the token.
-    var token: String { get }
+    var value: String { get }
     
     /// Expiration date of the token.
     var expiryDate: Date { get }

--- a/Platform/Networking/Instance.swift
+++ b/Platform/Networking/Instance.swift
@@ -338,8 +338,8 @@ import Foundation
                 switch result {
                 case .failure(let error): onError?(error)
                 case .authenticated(let token):
-                    let jwtFromTokenProvider = token.token
-                    let authHeaderValue = "Bearer \(jwtFromTokenProvider)"
+                    let tokenValue = token.value
+                    let authHeaderValue = "Bearer \(tokenValue)"
                     mutableRequestOptions.addHeaders(["Authorization": authHeaderValue])
                     requestMaker(mutableRequestOptions)
                 }

--- a/Platform/Networking/Instance.swift
+++ b/Platform/Networking/Instance.swift
@@ -337,7 +337,8 @@ import Foundation
             tokenProvider.fetchToken { result in
                 switch result {
                 case .failure(let error): onError?(error)
-                case .authenticated(let jwtFromTokenProvider):
+                case .authenticated(let token):
+                    let jwtFromTokenProvider = token.token
                     let authHeaderValue = "Bearer \(jwtFromTokenProvider)"
                     mutableRequestOptions.addHeaders(["Authorization": authHeaderValue])
                     requestMaker(mutableRequestOptions)

--- a/System Tests/Tests/Authentication/Token Provider/DefaultTokenProviderTests.swift
+++ b/System Tests/Tests/Authentication/Token Provider/DefaultTokenProviderTests.swift
@@ -16,7 +16,7 @@ class DefaultTokenProviderTests: XCTestCase {
         tokenProvider.fetchToken { result in
             switch result {
             case let .authenticated(token):
-                XCTAssertTrue(token.token.count > 0)
+                XCTAssertTrue(token.value.count > 0)
                 XCTAssertFalse(token.isExpired)
                 
             default:

--- a/Unit Tests/Tests/Authentication/Token Provider/DefaultTokenProviderTests.swift
+++ b/Unit Tests/Tests/Authentication/Token Provider/DefaultTokenProviderTests.swift
@@ -58,7 +58,7 @@ class DefaultTokenProviderTests: XCTestCase {
         tokenProvider.fetchToken { result in
             switch result {
             case let .authenticated(token):
-                XCTAssertTrue(token.token.count > 0)
+                XCTAssertTrue(token.value.count > 0)
                 XCTAssertFalse(token.isExpired)
                 
             default:

--- a/Unit Tests/Tests/Authentication/Token Provider/RetryableTokenProviderTests.swift
+++ b/Unit Tests/Tests/Authentication/Token Provider/RetryableTokenProviderTests.swift
@@ -20,7 +20,7 @@ class RetryableTokenProviderTests: XCTestCase {
     }
     
     func testShouldRetrieveTokenFromNestedTokenProvider() {
-        let testToken = TestToken(token: "testToken", expiryDate: .distantFuture)
+        let testToken = TestToken(value: "testToken", expiryDate: .distantFuture)
         let nestedTokenProvider = TestTokenProvider(testToken: testToken)
         
         let retryableTokenProvider = RetryableTokenProvider(tokenProvider: nestedTokenProvider)
@@ -43,7 +43,7 @@ class RetryableTokenProviderTests: XCTestCase {
     }
     
     func testShouldReturnCachedNonExpiredToken() {
-        let firstTestToken = TestToken(token: "firstTestToken", expiryDate: .distantFuture)
+        let firstTestToken = TestToken(value: "firstTestToken", expiryDate: .distantFuture)
         let nestedTokenProvider = TestTokenProvider(testToken: firstTestToken)
         
         let retryableTokenProvider = RetryableTokenProvider(tokenProvider: nestedTokenProvider)
@@ -56,7 +56,7 @@ class RetryableTokenProviderTests: XCTestCase {
         
         waitForExpectations(timeout: 1.0)
         
-        let secondTestToken = TestToken(token: "secondTestToken", expiryDate: .distantFuture)
+        let secondTestToken = TestToken(value: "secondTestToken", expiryDate: .distantFuture)
         nestedTokenProvider.testToken = secondTestToken
         
         let secondExpectation = self.expectation(description: "Second token retrieval")
@@ -77,7 +77,7 @@ class RetryableTokenProviderTests: XCTestCase {
     }
     
     func testShouldReturnDiscardCachedExpiredTokenAndRetrieveNewTokenFromNestedTokenProvider() {
-        let firstTestToken = TestToken(token: "firstTestToken", expiryDate: .distantPast)
+        let firstTestToken = TestToken(value: "firstTestToken", expiryDate: .distantPast)
         let nestedTokenProvider = TestTokenProvider(testToken: firstTestToken)
         
         let retryableTokenProvider = RetryableTokenProvider(tokenProvider: nestedTokenProvider)
@@ -90,7 +90,7 @@ class RetryableTokenProviderTests: XCTestCase {
         
         waitForExpectations(timeout: 1.0)
         
-        let secondTestToken = TestToken(token: "secondTestToken", expiryDate: .distantFuture)
+        let secondTestToken = TestToken(value: "secondTestToken", expiryDate: .distantFuture)
         nestedTokenProvider.testToken = secondTestToken
         
         let secondExpectation = self.expectation(description: "Second token retrieval")
@@ -111,7 +111,7 @@ class RetryableTokenProviderTests: XCTestCase {
     }
     
     func testShouldRetryFailedTokenFetchRequest() {
-        let testToken = TestToken(token: "testToken", expiryDate: .distantFuture)
+        let testToken = TestToken(value: "testToken", expiryDate: .distantFuture)
         let nestedTokenProvider = TestTokenProvider()
         
         let retryStrategyExpectation = self.expectation(description: "Retry")
@@ -264,7 +264,7 @@ extension RetryableTokenProviderTests {
         
         // MARK: - Properties
         
-        let token: String
+        let value: String
         let expiryDate: Date
         
     }

--- a/Unit Tests/Tests/Authentication/Token/OAuthTokenTests.swift
+++ b/Unit Tests/Tests/Authentication/Token/OAuthTokenTests.swift
@@ -12,7 +12,7 @@ class OAuthTokenTests: XCTestCase {
         }
         
         XCTAssertNoThrow(try OAuthToken(from: jsonData.jsonDecoder())) { token in
-            XCTAssertEqual(token.token, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Nzk2MDQxNDcsImlhdCI6MTU3OTUxNzc0NywiaW5zdGFuY2UiOiI5NzU1MTZmMS1mOWUzLTRlNTUtYTQ0ZC1lNDA3OTIzMmY5NDciLCJpc3MiOiJhcGlfa2V5cy80ZTQyOWNjNS0wM2YzLTQwNzctYmY4ZC04YTcxYWMwYWM2ODgiLCJzdWIiOiJib2IifQ.5uyq_dBsGfdyqnDVDhm7d0R9w6HGApllBLVhwYHCNBI")
+            XCTAssertEqual(token.value, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Nzk2MDQxNDcsImlhdCI6MTU3OTUxNzc0NywiaW5zdGFuY2UiOiI5NzU1MTZmMS1mOWUzLTRlNTUtYTQ0ZC1lNDA3OTIzMmY5NDciLCJpc3MiOiJhcGlfa2V5cy80ZTQyOWNjNS0wM2YzLTQwNzctYmY4ZC04YTcxYWMwYWM2ODgiLCJzdWIiOiJib2IifQ.5uyq_dBsGfdyqnDVDhm7d0R9w6HGApllBLVhwYHCNBI")
             XCTAssertEqual(token.expiryDate.timeIntervalSinceNow, 86400, accuracy: 0.001)
         }
     }

--- a/Unit Tests/Tests/Authentication/Token/TokenTests.swift
+++ b/Unit Tests/Tests/Authentication/Token/TokenTests.swift
@@ -9,7 +9,7 @@ class TokenTests: XCTestCase {
         
         // MARK: - Properties
         
-        let token: String
+        let value: String
         let expiryDate: Date
         
     }
@@ -17,13 +17,13 @@ class TokenTests: XCTestCase {
     // MARK: - Tests
     
     func testCorrectlyValidateNonExpiredToken() {
-        let token = TestToken(token: "token", expiryDate: Date.distantFuture)
+        let token = TestToken(value: "token", expiryDate: Date.distantFuture)
         
         XCTAssertFalse(token.isExpired)
     }
     
     func testCorrectlyValidateExpiredToken() {
-        let token = TestToken(token: "token", expiryDate: Date.distantPast)
+        let token = TestToken(value: "token", expiryDate: Date.distantPast)
         
         XCTAssertTrue(token.isExpired)
     }


### PR DESCRIPTION
### What?
Fixed bug with auth where the full description of the ` Token` *entity* was being sent to the server rather than just the JWT String value instead.

### Why?
Coz we want PP to work :-)


----

CC @pusher/sigsdk
