### PR TITLE
OKP `InstanceLocator` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ fastlane/screenshots
 .swift-version
 
 *.DS_Store
+InstanceLocator

--- a/Platform.xcodeproj/project.pbxproj
+++ b/Platform.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 51;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		738A3EFF23E42D8E00B6A614 /* Make InstanceLocator File */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 738A3F0023E42D8E00B6A614 /* Build configuration list for PBXAggregateTarget "Make InstanceLocator File" */;
+			buildPhases = (
+				738A3F0323E42DA900B6A614 /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = "Make InstanceLocator File";
+			productName = "Make InstanceLocator File";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		2205078223D0876E002E31A2 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2205078123D0876E002E31A2 /* DispatchQueue+Extensions.swift */; };
 		2207208B23CDEAFD00FB4A3A /* DefaultTokenProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2207208A23CDEAFD00FB4A3A /* DefaultTokenProviderTests.swift */; };
@@ -77,6 +91,8 @@
 		33F37F781E0C20CC0048457F /* PPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F37F771E0C20CC0048457F /* PPRequest.swift */; };
 		738A3ED623E30F0F00B6A614 /* InstanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738A3ED523E30F0F00B6A614 /* InstanceTests.swift */; };
 		738A3EDA23E3135800B6A614 /* PPLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738A3ED923E3135800B6A614 /* PPLogger.swift */; };
+		738A3F0723E42E2900B6A614 /* InstanceLocator in Resources */ = {isa = PBXBuildFile; fileRef = 738A3F0623E42E2900B6A614 /* InstanceLocator */; };
+		738A3F0A23E42F2E00B6A614 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738A3F0923E42F2E00B6A614 /* String+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +109,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 33831C881A9CF61600B124F1;
 			remoteInfo = PusherSwift;
+		};
+		738A3F0423E42DFC00B6A614 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 33831C4A1A9CEDF800B124F1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 738A3EFF23E42D8E00B6A614;
+			remoteInfo = "Make InstanceLocator File";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -173,6 +196,8 @@
 		33F37F771E0C20CC0048457F /* PPRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PPRequest.swift; sourceTree = "<group>"; };
 		738A3ED523E30F0F00B6A614 /* InstanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceTests.swift; sourceTree = "<group>"; };
 		738A3ED923E3135800B6A614 /* PPLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PPLogger.swift; sourceTree = "<group>"; };
+		738A3F0623E42E2900B6A614 /* InstanceLocator */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = InstanceLocator; sourceTree = SOURCE_ROOT; };
+		738A3F0923E42F2E00B6A614 /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -240,6 +265,7 @@
 			isa = PBXGroup;
 			children = (
 				2207209223CE1F5A00FB4A3A /* ProcessInfo+Extensions.swift */,
+				738A3F0923E42F2E00B6A614 /* String+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -395,6 +421,7 @@
 		2277526323CDE5300046F15F /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				738A3F0623E42E2900B6A614 /* InstanceLocator */,
 				2277525E23CDE4C50046F15F /* Info.plist */,
 			);
 			path = "Supporting Files";
@@ -654,6 +681,7 @@
 			);
 			dependencies = (
 				2299919823CF420200B9D4CE /* PBXTargetDependency */,
+				738A3F0523E42DFC00B6A614 /* PBXTargetDependency */,
 			);
 			name = "System Tests";
 			productName = "Functional Tests";
@@ -720,6 +748,9 @@
 						DevelopmentTeam = H7FL434D9W;
 						LastSwiftMigration = 1130;
 					};
+					738A3EFF23E42D8E00B6A614 = {
+						CreatedOnToolsVersion = 11.3.1;
+					};
 				};
 			};
 			buildConfigurationList = 33831C4D1A9CEDF800B124F1 /* Build configuration list for PBXProject "Platform" */;
@@ -738,6 +769,7 @@
 				33831C881A9CF61600B124F1 /* Platform */,
 				33831C931A9CF61600B124F1 /* Unit Tests */,
 				2277525923CDE4C50046F15F /* System Tests */,
+				738A3EFF23E42D8E00B6A614 /* Make InstanceLocator File */,
 			);
 		};
 /* End PBXProject section */
@@ -747,6 +779,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				738A3F0723E42E2900B6A614 /* InstanceLocator in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -787,6 +820,23 @@
 			shellPath = /bin/sh;
 			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
+		738A3F0323E42DA900B6A614 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Checks if an `<repo-root>/InstanceLocator` file exists and if it does not \n# creates one with contents \"<UNSPECIFIED>\"\n# Note the `<repo-root>/InstanceLocator` file is included in `.gitignore`\n\nINSTANCE_LOCATOR_FILEPATH=\"${SRCROOT}/InstanceLocator\"\n\necho \"Checking for existance of file '${INSTANCE_LOCATOR_FILEPATH}'\"\n\nif test ! -f \"${INSTANCE_LOCATOR_FILEPATH}\"; then\n    echo \"File missing, creating now...\"\n    echo \"<UNSPECIFIED>\" >> \"${INSTANCE_LOCATOR_FILEPATH}\"\n    echo \"Done\"\nelse \n    echo \"File exists, nothing to do.\"\nfi\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -798,6 +848,7 @@
 				2207209323CE1F5A00FB4A3A /* ProcessInfo+Extensions.swift in Sources */,
 				2207209623CE247400FB4A3A /* URL+Extensions.swift in Sources */,
 				2207208E23CE116600FB4A3A /* Environment.swift in Sources */,
+				738A3F0A23E42F2E00B6A614 /* String+Extensions.swift in Sources */,
 				2207209023CE136400FB4A3A /* CI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -889,6 +940,11 @@
 			isa = PBXTargetDependency;
 			target = 33831C881A9CF61600B124F1 /* Platform */;
 			targetProxy = 33831C961A9CF61600B124F1 /* PBXContainerItemProxy */;
+		};
+		738A3F0523E42DFC00B6A614 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 738A3EFF23E42D8E00B6A614 /* Make InstanceLocator File */;
+			targetProxy = 738A3F0423E42DFC00B6A614 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1119,6 +1175,18 @@
 			};
 			name = Release;
 		};
+		738A3F0123E42D8E00B6A614 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		738A3F0223E42D8E00B6A614 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1154,6 +1222,15 @@
 			buildConfigurations = (
 				33831CA11A9CF61600B124F1 /* Debug */,
 				33831CA21A9CF61600B124F1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		738A3F0023E42D8E00B6A614 /* Build configuration list for PBXAggregateTarget "Make InstanceLocator File" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				738A3F0123E42D8E00B6A614 /* Debug */,
+				738A3F0223E42D8E00B6A614 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Platform.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Platform.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/System Tests/Environment/Environment.swift
+++ b/System Tests/Environment/Environment.swift
@@ -4,17 +4,57 @@ struct Environment {
     
     // MARK: - Properties
     
-    static let instanceLocator: String = Environment.variable(named: "INSTANCE_LOCATOR", ciValue: CI.instanceLocator)
+    static let instanceLocator: String = Environment.variable(named: "INSTANCE_LOCATOR")
+    
+}
+
+// MARK: - Value retrieval
+
+extension Environment {
     
     // MARK: - Private methods
     
-    private static func variable(named name: String, ciValue: String) -> String {
-        guard let value = ProcessInfo.processInfo.environment[name], value != ProcessInfo.unspecifiedValue else {
-            assert(!ciValue.hasPrefix("$(") && !ciValue.hasSuffix(")"), "Please specify the value of the variable in either the enviroment variables section of your current run scheme or inject the value using Swift Variable Injector from Bitrise.")
+    private static func variable(named name: String) -> String {
+        
+        if let environmentValue = self.environmentVariable(named: name), environmentValue != ProcessInfo.unspecifiedValue {
+            return environmentValue
+        }
+        else if let ciValue = self.ciVariable(named: name), !ciValue.hasPrefix("$(") && !ciValue.hasSuffix(")") {
             return ciValue
         }
+        else if let repoFileValue = self.repoFile(named: name), repoFileValue != ProcessInfo.unspecifiedValue {
+            return repoFileValue
+        }
         
-        return value
+        preconditionFailure("Please specify the value of the variable in either i) the enviroment variables section of your current run scheme, or ii) by injecting the value using Swift Variable Injector from Bitrise, or iii) defining it in the dedicated file in the root of the repo.")
     }
     
+    private static func environmentVariable(named name: String) -> String? {
+        return ProcessInfo.processInfo.environment[name]
+    }
+    
+    private static func ciVariable(named name: String) -> String? {
+        let mirror = Mirror(reflecting: CI())
+        return mirror.children.first { $0.label == name.hungarianCased(separator: "_") }?.value as? String
+    }
+    
+    private static func repoFile(named name: String) -> String? {
+        
+        // Load the first line from file `InstanceLocator` thats included in the framework bundle
+        let filename = name.camelcased(separator: "_")
+
+        class ForBundleLocation {} // We need a *class* to be able to use `Bundle(for:)`.
+        let environmentBundle = Bundle(for: ForBundleLocation.self)
+        
+        if let path = environmentBundle.path(forResource: filename, ofType: nil),
+            let fileContent = try? String(contentsOfFile: path, encoding: .utf8) {
+            
+            let lines = fileContent.components(separatedBy: .newlines)
+            if lines.count > 0 {
+                return lines[0]
+            }
+        }
+        
+        return nil
+    }
 }

--- a/System Tests/Environment/Extensions/String+Extensions.swift
+++ b/System Tests/Environment/Extensions/String+Extensions.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+internal extension String {
+    
+    // MARK: - Internal methods
+    
+    func camelcased(separator: Character) -> String {
+        return self.split(separator: separator)
+            .map { return $0.lowercased().capitalizingFirstLetter() }
+            .joined()
+    }
+    
+    func hungarianCased(separator: Character) -> String {
+        return self.camelcased(separator: separator).lowercasingFirstLetter()
+    }
+    
+    // MARK: - Private methods
+    
+    private func capitalizingFirstLetter() -> String {
+        return prefix(1).uppercased() + dropFirst()
+    }
+    
+    private func lowercasingFirstLetter() -> String {
+        return prefix(1).lowercased() + dropFirst()
+    }
+    
+}

--- a/Unit Tests/Tests/Authentication/Token/OAuthTokenTests.swift
+++ b/Unit Tests/Tests/Authentication/Token/OAuthTokenTests.swift
@@ -13,7 +13,7 @@ class OAuthTokenTests: XCTestCase {
         
         XCTAssertNoThrow(try OAuthToken(from: jsonData.jsonDecoder())) { token in
             XCTAssertEqual(token.value, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1Nzk2MDQxNDcsImlhdCI6MTU3OTUxNzc0NywiaW5zdGFuY2UiOiI5NzU1MTZmMS1mOWUzLTRlNTUtYTQ0ZC1lNDA3OTIzMmY5NDciLCJpc3MiOiJhcGlfa2V5cy80ZTQyOWNjNS0wM2YzLTQwNzctYmY4ZC04YTcxYWMwYWM2ODgiLCJzdWIiOiJib2IifQ.5uyq_dBsGfdyqnDVDhm7d0R9w6HGApllBLVhwYHCNBI")
-            XCTAssertEqual(token.expiryDate.timeIntervalSinceNow, 86400, accuracy: 0.001)
+            XCTAssertEqual(token.expiryDate.timeIntervalSinceNow, 86400, accuracy: 0.01)
         }
     }
     


### PR DESCRIPTION

### What?
Added mechanism for possibility of defining your development instance locator in an `InstanceLocator` file in the root of the repo (currently for use in "System Tests" only).

### Why?
Prevents accidental checkins of changes to xcscheme.


----

CC @pusher/sigsdk
